### PR TITLE
release: v0.4.0 — version bump prep

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -63,7 +63,7 @@
     "operatingSystem": "macOS 13+",
     "url": "https://brew-browser.zerologic.com/",
     "downloadUrl": "https://github.com/msitarzewski/brew-browser/releases/latest",
-    "softwareVersion": "0.3.1",
+    "softwareVersion": "0.4.0",
     "license": "https://opensource.org/licenses/MIT",
     "author": {
       "@type": "Person",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "brew-browser"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brew-browser"
-version = "0.3.1"
+version = "0.4.0"
 description = "An honestly open Homebrew browser, manager, and Brewfile snapshot tool."
 authors = ["Michael Sitarzewski"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "brew-browser",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.zerologic.brew-browser",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Four-line mechanical bump (Cargo.toml, Cargo.lock, tauri.conf.json, landing/index.html) ahead of the v0.4.0 signed release.

After this merges, the build/sign/notarize/publish pipeline runs:

```
tools/build/sign-and-notarize.sh
tools/release/publish-manifest.sh 0.4.0
gh release create v0.4.0 ...
gh api PATCH .../assets/<id> -f name=brew-browser_0.4.0_aarch64.app.tar.gz
rsync updater.json brew-browser.zerologic.com:Sites/brew-browser/
```

cargo build clean against the bumped version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)