### PR TITLE
release: v0.5.0 — version bump prep

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -63,7 +63,7 @@
     "operatingSystem": "macOS 13+",
     "url": "https://brew-browser.zerologic.com/",
     "downloadUrl": "https://github.com/msitarzewski/brew-browser/releases/latest",
-    "softwareVersion": "0.4.0",
+    "softwareVersion": "0.5.0",
     "license": "https://opensource.org/licenses/MIT",
     "author": {
       "@type": "Person",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "brew-browser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brew-browser"
-version = "0.4.0"
+version = "0.5.0"
 description = "An honestly open Homebrew browser, manager, and Brewfile snapshot tool."
 authors = ["Michael Sitarzewski"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "brew-browser",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.zerologic.brew-browser",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Version bump 0.4.0 → 0.5.0 across the four canonical version sites:

- \`src-tauri/Cargo.toml\`
- \`src-tauri/Cargo.lock\` (brew-browser package entry only — leaves transitive deps alone)
- \`src-tauri/tauri.conf.json\`
- \`landing/index.html\` (\`softwareVersion\` schema.org field)

Same pattern as the v0.4.0 release branch. Version-only change so the release-cut commit stays a clean diff.

## Test plan

- [ ] Confirm the diff is 4 files, +4/-4 lines, version strings only
- [ ] After merge: \`tools/build/sign-and-notarize.sh\` → \`tools/release/publish-manifest.sh 0.5.0\` → \`gh release create v0.5.0 ...\` → asset rename + manifest rsync

🤖 Generated with [Claude Code](https://claude.com/claude-code)