### PR TITLE
docs: README + landing — v0.4.0 + v0.5.0 features and posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Homebrew is the standard package manager on macOS. brew-browser gives it a real 
 
 ## Features
 
-- **Dashboard** — your Homebrew setup at a glance: installed count, updates available, brew version, formula/cask split, top-categories donut chart, storage usage (Cellar / Caskroom / var/log / cache) with one-click "Reveal in Finder"
-- **Library** — every installed formula and cask in one dense, filterable list, with outdated badges, sortable columns, category chip filters, and a slide-over detail panel
+- **Dashboard** — your Homebrew setup at a glance: installed count, updates available, brew version, formula/cask split, top-categories donut chart, storage usage (Cellar / Caskroom / var/log / cache) with one-click "Reveal in Finder", and an opt-in **Exposure** card surfacing known vulnerabilities across your install
+- **Library** — every installed formula and cask in one dense, filterable list, with outdated badges, sortable columns, category chip filters, an opt-in **Vulnerable** filter pill, inline severity dots, and a slide-over detail panel
 - **Discover** — search the full Homebrew catalog (15,974 packages, bundled at build time + user-refreshable) by name or browse via the 19-category tile grid; multi-select chip filter
-- **Trending** — top packages from Homebrew's published `formulae.brew.sh` analytics, with 30 / 90 / 365-day windows and sortable columns
+- **Trending** — top packages from Homebrew's published `formulae.brew.sh` analytics, with 30 / 90 / 365-day windows, sortable columns, a **velocity index** (recent-month vs prior-11-month adoption signal), and opt-in per-package install-trend sparklines
 - **Snapshots** — save and restore Brewfiles using Homebrew's own `brew bundle` mechanism; "set up a new Mac" in one click
 - **Services** — list, start, stop, and restart background services managed by launchd through `brew services`
-- **Activity** — every `brew` invocation streams live into a bottom drawer with full stdout/stderr; session history persists across launches (last 50 jobs, capped lines)
+- **Security** — opt-in vulnerability scanning. Surfaces known CVEs against your installed formulae via the official `brew vulns` subcommand (OSV.dev), with optional GHSA enrichment when you're signed into GitHub. Inline severity dots, per-package Security card with "Upgrade to fix" wired to the existing upgrade pipeline. Off by default; one-click installer for `brew vulns` itself when you opt in
+- **Activity** — every `brew` invocation streams live into a bottom drawer with full stdout/stderr; session history persists across launches (last 200 jobs, capped lines)
 
 A global Cmd+K command palette covers the verbs. Cmd+0 returns to the Dashboard; Cmd+1…6 jumps between sections. Cmd+, opens Settings. Click the 🍺 brand to return home. Window dragging works from any panel header (native macOS overlay title bar + NSVisualEffectView vibrancy).
 
@@ -115,7 +116,24 @@ Contributions welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the dev loop
 
 ## Status
 
-**v0.3.1** shipped (signed + notarized). All seven core panes live: Dashboard, Library, Discover (with bundled catalog + 15,725 AI-curated friendly names and summaries), Trending, Snapshots, Services, and Activity. Optional GitHub integration via OAuth Device Flow is intent-discovered — sign-in only prompts when you actually try to star / watch / file an issue, never as static UI clutter. The Keychain is touched lazily so a fresh install never triggers a macOS auth prompt unless you actually use a GitHub feature. Settings ships with Offline Mode and a corrupt-recovery default. Native macOS title bar with traffic-light alignment, collapsible sidebar with persistent type-ahead search, (i) info popovers in place of AI badges for every enriched field. Expect rough edges in some app-icon edge cases (pkg-installer casks without `.app` bundles) and first-run niceties.
+**v0.5.0** shipped (signed + notarized). All seven core panes live: Dashboard, Library, Discover (with bundled catalog + 15,725 AI-curated friendly names and summaries), Trending, Snapshots, Services, and Activity. Optional GitHub integration via OAuth Device Flow is intent-discovered — sign-in only prompts when you actually try to star / watch / file an issue, never as static UI clutter. Two opt-in surfaces beyond the always-on core: **Enhanced Trending History** (v0.4.0+) for per-package install-trend sparklines, and **Vulnerability Scanning** (v0.5.0+) shelling out to the official `brew vulns` subcommand for CVE surfacing against your installed formulae. Settings ships with Offline Mode and a corrupt-recovery default. Native macOS title bar with traffic-light alignment, collapsible sidebar with persistent type-ahead search, (i) info popovers in place of AI badges for every enriched field.
+
+**v0.5.0** — opt-in vulnerability scanning. Highlights:
+- **`brew vulns` integration.** New Settings → Network → Vulnerability Scanning subsection (opt-in, off by default) shells out to the official `Homebrew/homebrew-brew-vulns` subcommand by Andrew Nesbitt to query OSV.dev for known CVEs against installed formulae. One-click installer for the `brew vulns` subcommand itself when you opt in — no terminal required.
+- **Dashboard Exposure card.** Severity-tiered counts (critical/high/medium/low), ✓ clean-state framing when no vulns, Scan-now button. Hidden when feature off.
+- **Sidebar count badge.** Number of vulnerable packages with max-severity tone. Hidden when 0 or feature off.
+- **PackageRow severity dots + PackageDetail Security card.** Inline severity indicator on every vulnerable row. PackageDetail Security card with per-CVE rows, severity pills, "Patched in X" badges, **"Upgrade to fix"** wired to the existing brew upgrade pipeline. Empty-summary entries fall back to canonical detail pages (NVD / OSV / GHSA).
+- **Library Vulnerable filter pill.** Danger-toned count badge, pre-selected when you click "View vulnerable packages →" from the Dashboard.
+- **Optional GHSA enrichment.** When both vuln-scanning AND GitHub sign-in are on, GHSA-prefixed advisories pull richer descriptions, patched-version ranges, and reference links from `api.github.com/advisories`. Triple-gated; best-effort; 7-day cache.
+- **Install-set SHA-256 fingerprint.** Daily app opens with no install changes serve the cached report instantly instead of re-shelling `brew vulns` (60+ seconds on 200 packages).
+- **Post-install exposure heads-up.** Once-per-session, after a successful install/upgrade, a passive toast surfaces if you have vulnerable packages elsewhere — the "install a thing → notice you have N existing CVEs" moment.
+- **Cask coverage gap stated honestly.** `brew vulns` is formula-only; cask Security cards say so rather than faking clean state.
+
+**v0.4.0** — trending velocity + opt-in install-history endpoint. Highlights:
+- **Velocity index on Trending.** Default sort. Compares each package's recent-month installs to its prior-11-month average so genuinely emerging packages surface ahead of stably-popular ones. New 🔥 / ❄️ / dash badges per row.
+- **Parallel install + install-on-request fetch.** Server-side join across 30d/90d/365d windows lets the velocity math see all three time horizons in one pass instead of three sequential round-trips.
+- **Opt-in Enhanced Trending History.** New Settings → Network → Enhanced Trending History subsection (off by default; distinct trust boundary from `formulae.brew.sh`). When on, inline per-row sparklines on Trending + a per-package history chart on PackageDetail, fed by a project-operated endpoint (`brew-browser.zerologic.com/trending-history/*`) with IP-redacted server logs (the privacy claim is auditable — Caddy block pinned in `memory-bank/security.md` §16).
+- **Dashboard polish.** Donut center text removed — the legend already carries the affordance, and removing the inner text frees up the chart for a cleaner look on narrow windows.
 
 **v0.3.1** — same-day cumulative point release on top of v0.3.0. Highlights:
 - **Magic search.** Search now matches name + AI friendly-name + AI summary + upstream desc + category labels (and Tier B tags when they land). "video player" finds VLC, "Video & Audio" returns the whole category. Sub-20ms in-process scan via a new `local_search` IPC; replaces the old `brew search` shell-out.

--- a/landing/index.html
+++ b/landing/index.html
@@ -127,7 +127,7 @@
 
         <div class="feature">
           <h3>Trending</h3>
-          <p>Top packages from Homebrew's own published <code>formulae.brew.sh</code> install analytics. 30 / 90 / 365 day windows.</p>
+          <p>Top packages from Homebrew's own published <code>formulae.brew.sh</code> install analytics. 30 / 90 / 365 day windows, a velocity index (recent month vs prior eleven so genuinely emerging packages out-rank stably-popular ones), and opt-in per-package install-trend sparklines.</p>
         </div>
 
         <div class="feature">
@@ -151,6 +151,11 @@
         </div>
 
         <div class="feature">
+          <h3>Security</h3>
+          <p>Opt-in vulnerability scanning. Surfaces known CVEs against your installed formulae via the official <code>brew vulns</code> subcommand (OSV.dev under the hood), with optional GHSA enrichment when you're signed into GitHub. Dashboard Exposure card, Sidebar count badge, per-row severity dots, PackageDetail Security card with one-click <strong>Upgrade to fix</strong> wired straight to the existing upgrade pipeline. Off by default; first-launch posture unchanged.</p>
+        </div>
+
+        <div class="feature">
           <h3>Native &amp; fast</h3>
           <p>Tauri 2 native shell, system WebView, native macOS title bar with traffic-light alignment. Cmd+K command palette, Cmd+0…6 to jump between sections, persistent type-ahead search in the sidebar, drag-resizable detail pane, collapsible sidebar.</p>
         </div>
@@ -167,7 +172,7 @@
         <li><strong>No EULA.</strong> No click-through to use the app.</li>
         <li><strong>No telemetry.</strong> No analytics, no crash reporting, no third-party pixels.</li>
         <li><strong>No accounts.</strong> No sign-in, no cloud sync, no required services.</li>
-        <li><strong>No surprise network.</strong> Every outbound call is documented and gated. Nine paths total — Homebrew's analytics for Trending, the catalog refresh, cask homepage probes (SSRF-filtered), GitHub repo stats, GitHub OAuth + authed actions when you opt in, <code>brew</code> itself, your default browser, the updater manifest, and the signed updater artifact. Full enumeration in the <a href="https://github.com/msitarzewski/brew-browser/blob/main/README.md#open-source-posture">README network posture</a>. Flip on <strong>Offline Mode</strong> in Settings to block them all in one click.</li>
+        <li><strong>No surprise network.</strong> Every outbound call is documented and gated. Eleven paths total — Homebrew's analytics for Trending, the catalog refresh, cask homepage probes (SSRF-filtered), GitHub repo stats, GitHub OAuth + authed actions when you opt in, <code>brew</code> itself, your default browser, the updater manifest, the signed updater artifact, the opt-in Enhanced Trending History endpoint (project infra, IP-redacted logs), and the opt-in Vulnerability Scanning surface (OSV.dev + source forges via <code>brew vulns</code> subprocess + optional GHSA enrichment when you're also signed into GitHub). Full enumeration in the <a href="https://github.com/msitarzewski/brew-browser/blob/main/README.md#open-source-posture">README network posture</a>. Flip on <strong>Offline Mode</strong> in Settings to block them all in one click.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary

Backfills the README Status section + landing-page feature copy with v0.4.0 (which somehow skipped the README/landing entirely) AND v0.5.0 (vulnerability scanning, just shipped).

## README changes

- **Features list** gains a Security entry (vuln scanning + Upgrade-to-fix) and bullet-level call-outs for the Exposure card on Dashboard, the Vulnerable filter + severity dots on Library, and the velocity index + opt-in sparklines on Trending.
- **Status section** bumped to v0.5.0, with a full v0.5.0 highlights block AND a backfilled v0.4.0 block (velocity, parallel install+install-on-request fetch, opt-in Enhanced Trending History, donut polish). The Status copy never moved past v0.3.1 — fixing.
- Activity job cap corrected to 200 (was raised in v0.3.1, never reflected here).

## Landing changes

- New **Security** feature card mentioning \`brew vulns\` + OSV.dev + optional GHSA enrichment + the one-click Upgrade-to-fix affordance.
- Trending card extended to mention velocity + opt-in sparklines.
- \"Nine paths total\" → **\"Eleven paths total\"** with the two new opt-in paths enumerated (Enhanced Trending History + Vulnerability Scanning surface). Keeps the disclosure honest and parity with the README network posture.

## Test plan

- [ ] Read the diff — version-mention copy only; no JS, no asset refs touched
- [ ] After merge: redeploy the landing site via the usual rsync to umbp (separate from this PR's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)