### PR TITLE
fix: keep window draggable while Settings is open (#8)

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -174,7 +174,14 @@
 <style>
   .scrim {
     position: fixed;
-    inset: 0;
+    /* Start below the 36px window title bar (the macOS drag region) so
+       the window stays movable while Settings is open. A full `inset: 0`
+       scrim covers the title bar's `data-tauri-drag-region`, swallowing
+       the mousedown macOS needs to begin a window drag — so the window
+       was stuck until Settings closed (issue #8). Leaving the title bar
+       uncovered also matches native macOS, where the title bar stays at
+       full opacity while a sheet is open. */
+    inset: 36px 0 0 0;
     background: rgb(0 0 0 / 0.4);
     z-index: 90;
     animation: fadeIn var(--motion-duration-base) var(--motion-ease-out);


### PR DESCRIPTION
Fixes #8 — reported by @unluckyquote.

## The bug
With Settings open, the dimming scrim (`position: fixed; inset: 0; z-index: 90`) covered the entire window, including the 36px title bar that serves as the macOS window drag region (`data-tauri-drag-region`). With the drag region covered, macOS never received the mousedown it uses to begin a window drag — so the window couldn't be moved until Settings was closed.

## The fix
Start the scrim below the title bar (`inset: 36px 0 0 0`) so the drag region stays uncovered and live. This also matches native macOS, where the title bar stays at full opacity while a sheet is open.

Tested on macOS: with Settings open, the window drags by the title bar as expected, and click-outside-to-close still works.

`npm run check`: 0 errors.