### PR TITLE
fix(window): persist window size + position across launches (#17)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -4152,6 +4153,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,11 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+# Issue #17 — persist window size + position across launches. Registered in
+# `lib.rs`; auto-saves geometry on move/resize and on exit, then restores it
+# on the next launch. No frontend wiring — the plugin hooks window events
+# natively, so registration is the whole feature.
+tauri-plugin-window-state = "2"
 # Phase 15 — in-app updater (manifest fetch, sha256 + minisign verify,
 # atomic .app bundle replacement). Plugin endpoint + minisign public
 # key are wired in `tauri.conf.json` and `src/lib.rs` respectively.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-start-dragging",
     "dialog:allow-open",
     "dialog:allow-save",
-    "updater:default"
+    "updater:default",
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,12 @@ pub fn run() {
         // Offline Mode kills the path even though the plugin itself
         // would otherwise try the manifest endpoint.
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // Issue #17 — persist the window's size + position across launches.
+        // The plugin auto-saves geometry when the window is moved/resized and
+        // on exit, then restores it on the next launch. Default StateFlags
+        // cover size + position (plus maximized/fullscreen) — exactly what the
+        // issue asks for. No frontend wiring: registration is the feature.
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .menu(build_app_menu)
         .on_menu_event(handle_menu_event)
         .setup(|app| {


### PR DESCRIPTION
## What

Registers [`tauri-plugin-window-state`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/window-state) so the main window remembers its size and position between launches.

Resolves #17 — reported by @bytepl: resizing the window had no effect after a restart; it always reopened at the default size.

## How

- `src-tauri/Cargo.toml` — add `tauri-plugin-window-state = "2"` (resolves to 2.4.1)
- `src-tauri/src/lib.rs` — register the plugin in the builder chain, right after the updater plugin
- `src-tauri/capabilities/default.json` — add the `window-state:default` permission

The plugin hooks window move/resize/close events natively and writes geometry to a state file in the app config dir, restoring it on next launch. Default `StateFlags` cover **size + position + maximized/fullscreen**. No frontend wiring, no new IPC commands — registration is the whole feature.

The hardcoded `1100×720` in `tauri.conf.json` stays as the **first-launch default**, used only when no saved state exists.

## Notes

The window is `transparent: true` + `titleBarStyle: Overlay`. The plugin restores geometry only — independent of the title-bar style — so the custom traffic-light position and the drag region (#8) are unaffected.

## Verification

- `cargo check` — exit 0
- `cargo test --lib` — 585 passed, 0 failed (baseline unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)