### PR TITLE
docs(release-notes): credit window fix reporters (#8, #17)

### DIFF
--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,0 +1,13 @@
+## brew-browser (unreleased) — Window state persistence
+
+Signed + notarized. macOS 13+, Apple Silicon. Auto-updates via the in-app updater.
+
+> **Staging file.** Rename to `docs/release-notes/<version>.md` when the next version is cut.
+
+### What's new
+
+**The window remembers its size and position.** Resize or move the window, quit, and relaunch — it reopens exactly where and how you left it. Powered by `tauri-plugin-window-state`, which saves geometry on move/resize and on exit, then restores it on the next launch. The previous `1100×720` default is now used only on a true first launch. (#17, #19)
+
+### Acknowledgments
+
+- @bytepl (Maciej Chojnacki) for reporting the window-state issue (#17) with a clean, reproducible repro.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,4 +1,4 @@
-## brew-browser (unreleased) — Window state persistence
+## brew-browser (unreleased) — Window behavior fixes
 
 Signed + notarized. macOS 13+, Apple Silicon. Auto-updates via the in-app updater.
 
@@ -8,6 +8,11 @@ Signed + notarized. macOS 13+, Apple Silicon. Auto-updates via the in-app update
 
 **The window remembers its size and position.** Resize or move the window, quit, and relaunch — it reopens exactly where and how you left it. Powered by `tauri-plugin-window-state`, which saves geometry on move/resize and on exit, then restores it on the next launch. The previous `1100×720` default is now used only on a true first launch. (#17, #19)
 
+### Bug fixes
+
+**Window stays draggable with Settings open.** Opening Settings dims the main window with a scrim; previously that scrim covered the title bar's drag region, so you couldn't move the window without closing Settings first. The scrim is now inset below the 36px title bar, so the window drags normally with Settings open. (#8, #10)
+
 ### Acknowledgments
 
 - @bytepl (Maciej Chojnacki) for reporting the window-state issue (#17) with a clean, reproducible repro.
+- @unluckyquote (Nik) for reporting the unmovable-window-with-Settings-open bug (#8).


### PR DESCRIPTION
## What

Stages a next-version release-notes file (`docs/release-notes/unreleased.md`) covering the two window fixes that landed on `main` after the `v0.5.0` tag (so they're unreleased), and credits both reporters:

- **Window state persistence** (#17 / #19) — window remembers size + position across launches. Reported by @bytepl (Maciej Chojnacki).
- **Window draggable with Settings open** (#8 / #10) — the Settings scrim no longer covers the title-bar drag region. Reported by @unluckyquote (Nik).

Both reporters are credited in an **Acknowledgments** section.

## Why

Both fixes merged before a `Reported-by:` trailer could go on their commits. This is the clean alternative — it follows the existing reporter-credit pattern from [`0.3.1.md`](https://github.com/msitarzewski/brew-browser/blob/main/docs/release-notes/0.3.1.md) (`@heyjawrsh for the issue-#1 flow`).

Reporter credit, not a code-contributor claim — accurate to who did what.

## Note

The file is named `unreleased.md` because the next version number isn't assigned yet. Rename it to `docs/release-notes/<version>.md` when the release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)