### PR TITLE
feat(tauri): native parity — icons, Dashboard charts, 1-prompt keychain, velocity threshold

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,10 @@
 # Active Context
 
+**Date:** 2026-06-02 (Tauri←native parity pass on branch `tauri-parity`)
+**State:** Working on `tauri-parity` (rooted on `main`) — bringing the shipped Tauri app up to the native rebuild's icon + Dashboard-chart treatment, one-prompt Keychain, and the canonical Trending velocity threshold. Parity pass complete + verified (`npm run check` clean, Rust compiles, screenshots confirmed); committed + pushed. Full detail: `tasks/2026-06/01-tauri-native-parity.md`; ADR: `decisions.md#2026-06-02`. Reverse-parity backlog (native←Tauri) in memory `project-native-reverse-parity`. Prior context (v0.5.0 launch) below.
+
+---
+
 **Date:** 2026-05-30 EOD (v0.5.0 launched big; Homebrew tap live; post-launch fixes shipped)
 **State:** v0.5.0 released and **launched successfully on r/MacOS (Saturday — the only day app posts are allowed there)**. Final launch numbers: **29 → 128 stars in one day**; r/MacOS post 300↑ @ 92.6%, r/MacOSApps post 106↑ @ 97.3% (the predecessor closed-source "Homebrew Store" post that triggered this whole project was deleted by its author at 65%). Post-launch work all landed: issue #8 fix (merged, PR #10), Homebrew tap (live), docs across README/landing/memory-bank (merged, PR #11), landing site redeployed to the server (was stale at v0.3.0, now v0.5.0). First external contributor PR (#15) reviewed.
 

--- a/memory-bank/decisions.md
+++ b/memory-bank/decisions.md
@@ -346,3 +346,21 @@ The v0.4.0 outbound enumeration is at ten paths (path j is the most recent — o
 - **Nightly prebuilt cask-HEAD via CI** — deferred; needs Apple signing secrets in GitHub Actions + notarize-per-commit.
 
 **Outcome:** tap live at `msitarzewski/homebrew-brew-browser`. README + landing page updated to lead with the `brew` install. projectbrief Distribution section added.
+
+## 2026-06-02: Tauri←native parity on a main-rooted branch; canonical velocity threshold; one-prompt Keychain
+
+**Context:** The native macOS rebuild (`experiment/native-swift-liquid-glass`) pulled ahead in a few user-visible places. Per the parity charter (2026-06-01), the two builds are kept in feature/data-contract parity, so this work flows back to the shipped Tauri app. Full task record: `tasks/2026-06/01-tauri-native-parity.md`.
+
+**Decisions:**
+
+1. **Branch `tauri-parity` is rooted on `main`, not the experiment branch.** Verified every touched file (Svelte components, `auth.rs`, `Cargo.*`) was byte-identical between `main` and the experiment HEAD, so `git checkout main && git checkout -b tauri-parity` carried the uncommitted work over with zero conflicts. Keeps the eventual PR into `main` clean (no native commits in history). `native/` is untracked on this branch and excluded from commits.
+
+2. **Canonical Trending velocity badge = formula-faithful banded.** `velocity_index` (`velocity.rs`) is documented as "1.0≈steady, >1.5 surging, <0.7 cooling." Native shipped a BINARY `v >= 1 ? flame : snowflake`, which mislabels near-steady packages (e.g. 1.05) as surging. Canonical rule for BOTH builds: `>=1.5` 🔥 / `<=0.7` ❄️ / otherwise neutral (no icon). Tauri's `velocityTier` updated (cool bound 0.5→0.7); native's binary→banded change is the reverse-parity item (memory `project-native-reverse-parity`).
+
+3. **GitHub Keychain status check = one batched read.** Native collapsed three `SecItemCopyMatching` calls (token/username/scopes) into one `kSecMatchLimitAll` query → one auth prompt. Ported to Tauri via a `KeychainSlot::read_many` default (per-account) + a macOS `SystemKeychain` override using the `security-framework` crate's `ItemSearchOptions(...).limit(Limit::All)`. The `keyring` crate has no batch API, hence the direct Security-framework use. Three-account storage schema unchanged (keeps parity + existing users' tokens).
+
+**Rejected alternatives:**
+- *Single JSON-blob Keychain item* (one read, no new dep) — rejected: orphans existing tokens (forced re-sign-in) and diverges from native's three-account layout, breaking the keychain parity contract.
+- *Make Tauri's velocity match native's binary* — rejected: native is the less-correct side here; aligning to the formula's documented bands is the right canonical.
+
+**Outcome:** Tauri parity work complete and verified (`npm run check` clean, Rust compiles, screenshots confirmed). Native reverse-parity backlog captured in memory `project-native-reverse-parity`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,17 @@
 # Progress
 
+## 2026-06-02 — Tauri←native parity (branch `tauri-parity`)
+
+- ✅ Shared `PackageRowIcon.svelte` (Tauri analog of native `PackageIcon`); list icons added to Discover + Trending (had none), Library routed through it.
+- ✅ Detail panel: centered 64px app icon.
+- ✅ Dashboard: Composition pie + Top-categories side-by-side on wide panes; chips in card header; equal-height cards; charts matched to native specs (outer radius 60, donut inner ratio 0.6, filled `<path>` pie, vertical centering).
+- ✅ Keychain: one batched `SecItemCopyMatching` (one prompt) via `security-framework`, mirroring native `keychainReadAll`.
+- ✅ Trending velocity badge: canonical banded threshold (≥1.5 🔥 / ≤0.7 ❄️ / neutral).
+- ✅ `npm run check` 0 errors; Rust compiles; verified via screenshots. Committed + pushed.
+- ↩️ Reverse-parity (native←Tauri) tracked in memory `project-native-reverse-parity`: legend icons, banded velocity, Snapshots/Services panels.
+
+See `tasks/2026-06/01-tauri-native-parity.md` + `decisions.md#2026-06-02`.
+
 ## 2026-05-24 (overnight)
 
 ### Done since last sync

--- a/memory-bank/tasks/2026-06/01-tauri-native-parity.md
+++ b/memory-bank/tasks/2026-06/01-tauri-native-parity.md
@@ -1,0 +1,58 @@
+# 01 — Tauri←native feature parity
+
+**Date:** 2026-06-02
+**Branch:** `tauri-parity` (rooted on `main`, so it can PR cleanly later — NOT the experiment branch)
+
+## Objective
+
+Bring the shipped Tauri app up to the native rebuild's treatment of icons + Dashboard charts, collapse the GitHub Keychain reads to one prompt (as native already does), and reconcile the Trending velocity badge to one canonical threshold.
+
+## Outcome
+
+- ✅ `npm run check`: 0 errors (3 pre-existing warnings unrelated to these files)
+- ✅ Rust compiles clean via `tauri dev` (keychain change)
+- ✅ Verified visually via user screenshots (Dashboard wide/narrow, cask/formula detail, lists)
+
+## Files modified
+
+- `src/lib/components/PackageRowIcon.svelte` (**new**) — shared list/detail icon, Tauri analog of native's `PackageIcon`: resolved cask icon → `terminal` glyph (formulae) → `square-dashed` (unresolved casks). Glyph inherits `currentColor` so it tints on row selection. Casks resolve via `iconCache.getIcon`; Discover hits resolve homepage via `catalog.lookupCask`.
+- `src/lib/components/PackageRow.svelte` — Library rows route through `PackageRowIcon` (removed the duplicated inline icon state + CSS).
+- `src/lib/components/Discover.svelte` — added icon in the name cell of both row modes (search + browse); previously **no icons**.
+- `src/lib/components/Trending.svelte` — added icon in the name cell (formulae-only leaderboard → terminal glyph); previously **no icons**. Reconciled `velocityTier` threshold (below).
+- `src/lib/components/PackageDetail.svelte` — centered 64px app icon at the top of the detail body (kept the shared `.panel-head` pixel-alignment intact rather than restructuring the header bar).
+- `src/lib/components/Dashboard.svelte` — Composition pie + Top-categories paired side-by-side on wide panes (see below).
+- `src-tauri/Cargo.toml` + `Cargo.lock` — added `security-framework = "2"` (macOS target).
+- `src-tauri/src/github/auth.rs` — batched Keychain read (below).
+
+## Dashboard charts (matched to native specs)
+
+- **Layout:** Composition + Top-categories pair two-across once the pane is wide (`@container dash (min-width: 820px)` on `.body`, which tracks the *content pane* width — sidebar/inspector excluded, more correct than native's manual `onGeometryChange(>980)`). Below the breakpoint they stack full-width and Composition reverts to its horizontal bar.
+- **Pie:** filled SVG `<path>` wedges, outer radius **60** (fills the `0 0 120 120` viewBox = native's 180×180 frame). (A thick-stroke circle was ambiguous at the `stroke=2·r` boundary and rendered larger.)
+- **Donut:** `DONUT_RADIUS 48` + `24px` stroke → outer **60**, inner **36** = ratio **0.6**, matching native's `innerRadius: .ratio(0.6)`. Hover is now opacity-only (removed the stroke-width bump), matching native's `.opacity()`.
+- **Equal height + centering:** paired cards become flex columns; chart bodies flex-fill the (equal) card height; each chart is vertically centered — two same-size charts centered in equal-height cards line up, exactly how native does it.
+- **Chips:** `on request` / `as dependency` / `pinned` moved from a bottom row into the Composition card header upper-right (native's `CompositionCard` title row).
+
+## Keychain — one prompt (mirrors native `keychainReadAll`)
+
+- `KeychainSlot` trait gained `read_many(&[&str])` with a **default** impl (one `read` per account → N prompts) so tests + non-macOS backends are unaffected.
+- macOS `SystemKeychain` overrides `read_many` with `read_all_batch()`: one `ItemSearchOptions::new().class(generic_password).service(KEYCHAIN_SERVICE).load_attributes(true).load_data(true).limit(Limit::All).search()` → all GitHub items in **one** `SecItemCopyMatching` (one auth prompt). `errSecItemNotFound` → empty map (signed out); other errors → `KeychainUnavailable`. `simplify_dict()` keys: `acct` (account) / `v_Data` (value).
+- `status_with()` now does ONE `read_many([token, username, scopes])` instead of three `read()` calls. In dev (unsigned binary re-signed each build, ACL never matches) this is **3 → 1** prompts per launch; in a signed release the user hits "Always Allow" once.
+
+## Trending velocity threshold (canonical rule)
+
+Agreed canonical = **formula-faithful banded**, matching `velocity.rs`'s documented "1.0≈steady, >1.5 surging, <0.7 cooling":
+- `>= 1.5` → 🔥 surge
+- `<= 0.7` → ❄️ cool
+- otherwise → neutral (no icon, just the number)
+
+Tauri's `velocityTier` updated (cool bound `0.5 → 0.7`). **Native still uses a binary `v >= 1` rule** (`TrendingView.swift:velocityCell`) — its change to banded (incl. an iconless neutral state) is tracked in memory `project-native-reverse-parity`.
+
+## Reverse-parity (native←Tauri) — NOT in this task
+
+- Native Dashboard category-legend **icons** (user: keep in Tauri, add to native).
+- Native Trending **banded** velocity threshold (above).
+- Native **Snapshots** + **Services** panels (still placeholder stubs).
+
+## Notes
+
+- All on `tauri-parity`; `native/` is untracked here (it's tracked on the experiment branch) and is **not** part of this commit.

--- a/memory-bank/tasks/2026-06/README.md
+++ b/memory-bank/tasks/2026-06/README.md
@@ -1,0 +1,13 @@
+# Tasks — 2026-06
+
+Per-task records for June 2026 work on brew-browser.
+
+## Index
+
+| # | Task | Date | Branch | Release |
+|---|---|---|---|---|
+| 01 | [Tauri←native feature parity (icons, Dashboard charts, keychain one-prompt, velocity threshold)](./01-tauri-native-parity.md) | 2026-06-02 | `tauri-parity` | — |
+
+## Context
+
+The `experiment/native-swift-liquid-glass` rebuild (native macOS 26 app under `native/`) raced ahead in a few areas. Per the parity charter (`decisions.md` 2026-06-01 + memory `project-parity-charter`), feature/data-contract work is kept in sync across the two builds. This month's first task brings the shipped **Tauri** app up to the native build's treatment of list/detail icons and the Dashboard charts, consolidates the GitHub Keychain reads to a single prompt (mirroring native), and reconciles the Trending velocity badge threshold to a single canonical rule. The reverse direction (native←Tauri: legend icons, banded velocity, Snapshots/Services) is tracked separately.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "hex",
  "keyring",
  "reqwest 0.12.28",
+ "security-framework 2.11.1",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,6 +85,10 @@ url = "2"
 # call its macOS APIs.
 [target.'cfg(target_os = "macos")'.dependencies]
 window-vibrancy = "0.6"
+# Direct use of the Security framework for a single batched Keychain read
+# (one SecItemCopyMatching for all GitHub items → one auth prompt instead of
+# three). Pinned to "2" to unify with the version keyring already compiles.
+security-framework = "2"
 
 [dev-dependencies]
 # Reserved for future integration tests that need a sandbox dir

--- a/src-tauri/src/github/auth.rs
+++ b/src-tauri/src/github/auth.rs
@@ -39,6 +39,7 @@
 
 #![deny(clippy::print_stdout, clippy::print_stderr, clippy::dbg_macro)]
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -265,6 +266,23 @@ pub trait KeychainSlot: Send + Sync {
 
     /// Delete the entry, treating "no such entry" as success.
     fn delete(&self, account: &str) -> Result<(), BrewError>;
+
+    /// Read several accounts at once, returning only those with a value.
+    ///
+    /// Default: one `read` per account — N separate Keychain accesses, hence N
+    /// auth prompts. macOS [`SystemKeychain`] overrides this with a single
+    /// `SecItemCopyMatching(kSecMatchLimitAll)` so the launch-time sign-in check
+    /// (`status`) costs ONE prompt instead of three. (Mirrors native's
+    /// `keychainReadAll`.) The default keeps tests + non-macOS correct.
+    fn read_many(&self, accounts: &[&str]) -> Result<HashMap<String, String>, BrewError> {
+        let mut out = HashMap::new();
+        for &account in accounts {
+            if let Some(value) = self.read(account)? {
+                out.insert(account.to_string(), value);
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Production keychain backed by `keyring::Entry` against the macOS
@@ -278,6 +296,54 @@ impl SystemKeychain {
                 message: format!("entry({KEYCHAIN_SERVICE}, {account}): {e}"),
             }
         })
+    }
+
+    /// macOS: read every generic-password item stored under `KEYCHAIN_SERVICE`
+    /// in ONE `SecItemCopyMatching` (`kSecMatchLimitAll`), keyed by account.
+    /// One Keychain access → one auth prompt, vs one prompt per account when
+    /// read individually. `errSecItemNotFound` (nothing stored yet) maps to an
+    /// empty map, not an error. Verbatim intent of native's `keychainReadAll`.
+    #[cfg(target_os = "macos")]
+    fn read_all_batch() -> Result<HashMap<String, String>, BrewError> {
+        use security_framework::item::{ItemClass, ItemSearchOptions, Limit, SearchResult};
+
+        /// `errSecItemNotFound` — no matching items, i.e. signed out.
+        const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+        let results = match ItemSearchOptions::new()
+            .class(ItemClass::generic_password())
+            .service(KEYCHAIN_SERVICE)
+            .load_attributes(true)
+            .load_data(true)
+            .limit(Limit::All)
+            .search()
+        {
+            Ok(items) => items,
+            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => return Ok(HashMap::new()),
+            Err(e) => {
+                return Err(BrewError::KeychainUnavailable {
+                    message: format!("batch read ({KEYCHAIN_SERVICE}): {e}"),
+                })
+            }
+        };
+
+        // simplify_dict() returns the item's attributes as string pairs; the
+        // account lives under "acct" (kSecAttrAccount) and the secret under
+        // "v_Data" (kSecValueData). Our values (token/scopes JSON/username) are
+        // all UTF-8, so the lossy conversion is lossless here.
+        let mut out = HashMap::new();
+        for result in results {
+            if let SearchResult::Dict(_) = result {
+                if let Some(dict) = result.simplify_dict() {
+                    if let (Some(account), Some(value)) =
+                        (dict.get("acct"), dict.get("v_Data"))
+                    {
+                        out.insert(account.clone(), value.clone());
+                    }
+                }
+            }
+        }
+        Ok(out)
     }
 }
 
@@ -312,6 +378,15 @@ impl KeychainSlot for SystemKeychain {
             }),
         }
     }
+
+    /// macOS: collapse the per-account reads into one batched Keychain access
+    /// (one auth prompt). `accounts` is ignored — the batch returns every item
+    /// under the service and the caller picks the keys it needs. On non-macOS
+    /// this method is absent, so the trait default (per-account reads) applies.
+    #[cfg(target_os = "macos")]
+    fn read_many(&self, _accounts: &[&str]) -> Result<HashMap<String, String>, BrewError> {
+        Self::read_all_batch()
+    }
 }
 
 // ---------- Status + sign-out (sync) ----------
@@ -322,18 +397,26 @@ impl KeychainSlot for SystemKeychain {
 /// alongside the token. If the token row is missing, returns the
 /// "not signed in" shape.
 pub fn status_with(keychain: &dyn KeychainSlot) -> Result<GithubStatusDto, BrewError> {
-    let token = keychain.read(KEYCHAIN_ACCOUNT_TOKEN)?;
-    if token.is_none() {
+    // ONE batched Keychain read for token + username + scopes (macOS: one auth
+    // prompt; other backends: the trait default does per-account reads).
+    let all = keychain.read_many(&[
+        KEYCHAIN_ACCOUNT_TOKEN,
+        KEYCHAIN_ACCOUNT_USERNAME,
+        KEYCHAIN_ACCOUNT_SCOPES,
+    ])?;
+
+    if !all.contains_key(KEYCHAIN_ACCOUNT_TOKEN) {
         return Ok(GithubStatusDto {
             signed_in: false,
             username: None,
             scopes: Vec::new(),
         });
     }
-    let username = keychain.read(KEYCHAIN_ACCOUNT_USERNAME)?;
-    let scopes_raw = keychain.read(KEYCHAIN_ACCOUNT_SCOPES)?;
-    let scopes: Vec<String> = scopes_raw
-        .and_then(|s| serde_json::from_str(&s).ok())
+
+    let username = all.get(KEYCHAIN_ACCOUNT_USERNAME).cloned();
+    let scopes: Vec<String> = all
+        .get(KEYCHAIN_ACCOUNT_SCOPES)
+        .and_then(|s| serde_json::from_str(s).ok())
         .unwrap_or_default();
     Ok(GithubStatusDto {
         signed_in: true,

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -294,6 +294,54 @@
     return { formulaPct: fp, caskPct: 100 - fp };
   });
 
+  /** Composition pie segments (formulae vs casks) for the wide side-by-side
+   *  layout — mirrors native's CompositionCard pie. Same data as `split`,
+   *  shaped for the SVG-arc renderer the donut already uses. */
+  let compositionSegments = $derived.by<
+    Array<{ label: string; count: number; pct: number; startPct: number; color: string }>
+  >(() => {
+    const total = counts.formulae + counts.casks;
+    if (total === 0) return [];
+    const items = [
+      { label: "Formulae", count: counts.formulae, color: "var(--color-info, #4a90e2)" },
+      { label: "Casks", count: counts.casks, color: "var(--color-brand, #f59e0b)" },
+    ];
+    let cum = 0;
+    return items.map((s) => {
+      const pct = (s.count / total) * 100;
+      const seg = { ...s, pct, startPct: cum };
+      cum += pct;
+      return seg;
+    });
+  });
+
+  // Pie drawn as filled SVG wedges with outer radius 60 — fills the 120 viewBox
+  // (= native's 180×180 frame) and exactly matches the donut's outer radius, so
+  // the two charts render at an identical diameter.
+  const PIE_RADIUS = 60;
+
+  /** SVG path `d` for a pie wedge spanning [startPct, startPct+pct] of the
+   *  circle, starting at 12 o'clock and sweeping clockwise. Center (60,60),
+   *  r=56 in the shared `0 0 120 120` viewBox. Handles the full-circle case
+   *  (one category at 100%, which a single arc can't close). */
+  function piePath(startPct: number, pct: number): string {
+    const r = PIE_RADIUS;
+    const cx = 60;
+    const cy = 60;
+    if (pct <= 0) return "";
+    if (pct >= 100) {
+      return `M ${cx} ${cy - r} A ${r} ${r} 0 1 1 ${cx} ${cy + r} A ${r} ${r} 0 1 1 ${cx} ${cy - r} Z`;
+    }
+    const a0 = (startPct / 100) * 2 * Math.PI - Math.PI / 2;
+    const a1 = ((startPct + pct) / 100) * 2 * Math.PI - Math.PI / 2;
+    const x0 = (cx + r * Math.cos(a0)).toFixed(3);
+    const y0 = (cy + r * Math.sin(a0)).toFixed(3);
+    const x1 = (cx + r * Math.cos(a1)).toFixed(3);
+    const y1 = (cy + r * Math.sin(a1)).toFixed(3);
+    const largeArc = pct > 50 ? 1 : 0;
+    return `M ${cx} ${cy} L ${x0} ${y0} A ${r} ${r} 0 ${largeArc} 1 ${x1} ${y1} Z`;
+  }
+
   /**
    * Top-N categories among installed packages, with counts. We weight by single
    * membership (each package contributes 1 to each category it's tagged with;
@@ -339,7 +387,10 @@
     "#f97316", // orange
     "#64748b", // slate (used for "Other")
   ];
-  const DONUT_RADIUS = 46;
+  // r 48 + half the 24px stroke = outer radius 60 (fills the 120 viewBox, like
+  // native's 180×180 frame); inner radius 48 − 12 = 36 = ratio 0.6 of the outer,
+  // matching native's donut innerRadius .ratio(0.6).
+  const DONUT_RADIUS = 48;
   const DONUT_CIRC = 2 * Math.PI * DONUT_RADIUS;
 
   /**
@@ -610,39 +661,134 @@
         </section>
       {/if}
 
-      <!-- Composition -->
-      <section class="card">
-        <div class="card-head">
-          <h2>Composition</h2>
-        </div>
-        <div class="split">
-          <div class="split-bar" role="img" aria-label={`${counts.formulae} formulae and ${counts.casks} casks`}>
-            <span class="seg seg--formula" style="width: {split.formulaPct}%"></span>
-            <span class="seg seg--cask" style="width: {split.caskPct}%"></span>
+      <!-- Composition + Top categories — paired side-by-side on wide panes
+           (matches native's >980px breakpoint); stacked full-width below,
+           where Composition reverts to a horizontal bar. -->
+      <div class="dash-pair" class:paired={categories.visible && categorySegments.length > 0}>
+        <section class="card comp-card">
+          <div class="card-head">
+            <h2>Composition</h2>
+            <!-- on-request / as-dependency / pinned chips live in the header
+                 upper-right (matches native's CompositionCard title row). -->
+            <div class="comp-chips">
+              {#if counts.onRequest > 0}
+                <span class="meta-pill">{fmt(counts.onRequest)} on request</span>
+              {/if}
+              {#if counts.asDependency > 0}
+                <span class="meta-pill">{fmt(counts.asDependency)} as dependency</span>
+              {/if}
+              {#if counts.pinned > 0}
+                <span class="meta-pill">{fmt(counts.pinned)} pinned</span>
+              {/if}
+            </div>
           </div>
-          <div class="split-legend">
-            <span class="legend">
-              <span class="swatch swatch--formula"></span>
-              <strong>{fmt(counts.formulae)}</strong> formulae
-            </span>
-            <span class="legend">
-              <span class="swatch swatch--cask"></span>
-              <strong>{fmt(counts.casks)}</strong> casks
-            </span>
+          <div class="split">
+            <!-- Wide + paired: pie + ranked legend (rhymes with the donut). -->
+            <div class="comp-pie">
+              <svg viewBox="0 0 120 120" class="pie" role="img" aria-label={`${counts.formulae} formulae and ${counts.casks} casks`}>
+                {#each compositionSegments as s (s.label)}
+                  <path d={piePath(s.startPct, s.pct)} fill={s.color} />
+                {/each}
+              </svg>
+              <ul class="pie-legend">
+                {#each compositionSegments as s (s.label)}
+                  <li>
+                    <span class="legend-dot" style="background: {s.color}"></span>
+                    <span class="legend-label">{s.label}</span>
+                    <span class="legend-count">{fmt(s.count)}</span>
+                    <span class="legend-pct text-muted">{s.pct.toFixed(1)}%</span>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+            <!-- Default (narrow / unpaired): stacked horizontal bar. -->
+            <div class="comp-bar">
+              <div class="split-bar" role="img" aria-label={`${counts.formulae} formulae and ${counts.casks} casks`}>
+                <span class="seg seg--formula" style="width: {split.formulaPct}%"></span>
+                <span class="seg seg--cask" style="width: {split.caskPct}%"></span>
+              </div>
+              <div class="split-legend">
+                <span class="legend">
+                  <span class="swatch swatch--formula"></span>
+                  <strong>{fmt(counts.formulae)}</strong> formulae
+                </span>
+                <span class="legend">
+                  <span class="swatch swatch--cask"></span>
+                  <strong>{fmt(counts.casks)}</strong> casks
+                </span>
+              </div>
+            </div>
           </div>
-          <div class="meta-row">
-            {#if counts.onRequest > 0}
-              <span class="meta-pill">{fmt(counts.onRequest)} on request</span>
-            {/if}
-            {#if counts.asDependency > 0}
-              <span class="meta-pill">{fmt(counts.asDependency)} as dependency</span>
-            {/if}
-            {#if counts.pinned > 0}
-              <span class="meta-pill">{fmt(counts.pinned)} pinned</span>
-            {/if}
+        </section>
+
+        <!-- Top categories — donut. Phase 13: hidden when the AI Features
+             toggle is off (categories are LLM-generated). -->
+        {#if categories.visible && categorySegments.length > 0}
+        <section class="card">
+          <div class="card-head">
+            <h2>Top categories in your library</h2>
           </div>
-        </div>
-      </section>
+          <div class="donut-wrap">
+            <svg viewBox="0 0 120 120" class="donut" role="img" aria-label="Category breakdown">
+              <circle cx="60" cy="60" r={DONUT_RADIUS} class="donut-track" />
+              {#each categorySegments as s (s.slug)}
+                {@const isHovered = hoveredCategory === s.slug}
+                {@const isDimmed = hoveredCategory !== null && !isHovered}
+                <!--
+                  Slices are decorative+hover-preview only. The canonical
+                  click target is the matching legend row below (real
+                  <button>, full keyboard support, screen-reader-named).
+                  Slice carries a <title> tooltip for mouse users who
+                  hover over the chart itself rather than the legend.
+                -->
+                <circle
+                  cx="60"
+                  cy="60"
+                  r={DONUT_RADIUS}
+                  fill="none"
+                  stroke={s.color}
+                  stroke-width={24}
+                  stroke-dasharray="{(s.pct / 100) * DONUT_CIRC} {DONUT_CIRC}"
+                  stroke-dashoffset="{-(s.startPct / 100) * DONUT_CIRC}"
+                  transform="rotate(-90 60 60)"
+                  class="donut-slice"
+                  class:donut-slice--dim={isDimmed}
+                  role="presentation"
+                  onmouseenter={() => (hoveredCategory = s.slug)}
+                  onmouseleave={() => (hoveredCategory = null)}
+                >
+                  <title>{s.label}: {fmt(s.count)} ({s.pct.toFixed(1)}%)</title>
+                </circle>
+              {/each}
+            </svg>
+            <ul class="donut-legend">
+              {#each categorySegments as s (s.slug)}
+                {@const Icon = resolveCategoryIcon(s.icon)}
+                {@const isHovered = hoveredCategory === s.slug}
+                <li>
+                  <button
+                    class="legend-row"
+                    class:legend-row--hover={isHovered}
+                    onclick={() => jumpToCategory(s.slug)}
+                    onmouseenter={() => (hoveredCategory = s.slug)}
+                    onmouseleave={() => (hoveredCategory = null)}
+                    onfocus={() => (hoveredCategory = s.slug)}
+                    onblur={() => (hoveredCategory = null)}
+                    title={s.slug === "__other__" ? "Browse all in Discover" : `Browse ${s.label} in Discover`}
+                  >
+                    <span class="legend-dot" style="background: {s.color}"></span>
+                    <span class="legend-icon"><Icon size={12} /></span>
+                    <span class="legend-label truncate">{s.label}</span>
+                    <span class="legend-count">{fmt(s.count)}</span>
+                    <span class="legend-pct text-muted">{s.pct.toFixed(1)}%</span>
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        </section>
+        {/if}
+      </div>
 
       <!-- Phase 12f — GitHub personal-stats card. Only when signed in,
            toggle enabled, and paranoid mode off. Hidden entirely
@@ -683,74 +829,6 @@
                 </p>
               {/if}
             {/if}
-          </div>
-        </section>
-      {/if}
-
-      <!-- Top categories — donut. Phase 13: hidden when the AI Features
-           toggle is off (categories are LLM-generated). -->
-      {#if categories.visible && categorySegments.length > 0}
-        <section class="card">
-          <div class="card-head">
-            <h2>Top categories in your library</h2>
-          </div>
-          <div class="donut-wrap">
-            <svg viewBox="0 0 120 120" class="donut" role="img" aria-label="Category breakdown">
-              <circle cx="60" cy="60" r={DONUT_RADIUS} class="donut-track" />
-              {#each categorySegments as s (s.slug)}
-                {@const isHovered = hoveredCategory === s.slug}
-                {@const isDimmed = hoveredCategory !== null && !isHovered}
-                <!--
-                  Slices are decorative+hover-preview only. The canonical
-                  click target is the matching legend row below (real
-                  <button>, full keyboard support, screen-reader-named).
-                  Slice carries a <title> tooltip for mouse users who
-                  hover over the chart itself rather than the legend.
-                -->
-                <circle
-                  cx="60"
-                  cy="60"
-                  r={DONUT_RADIUS}
-                  fill="none"
-                  stroke={s.color}
-                  stroke-width={isHovered ? 24 : 20}
-                  stroke-dasharray="{(s.pct / 100) * DONUT_CIRC} {DONUT_CIRC}"
-                  stroke-dashoffset="{-(s.startPct / 100) * DONUT_CIRC}"
-                  transform="rotate(-90 60 60)"
-                  class="donut-slice"
-                  class:donut-slice--dim={isDimmed}
-                  role="presentation"
-                  onmouseenter={() => (hoveredCategory = s.slug)}
-                  onmouseleave={() => (hoveredCategory = null)}
-                >
-                  <title>{s.label}: {fmt(s.count)} ({s.pct.toFixed(1)}%)</title>
-                </circle>
-              {/each}
-            </svg>
-            <ul class="donut-legend">
-              {#each categorySegments as s (s.slug)}
-                {@const Icon = resolveCategoryIcon(s.icon)}
-                {@const isHovered = hoveredCategory === s.slug}
-                <li>
-                  <button
-                    class="legend-row"
-                    class:legend-row--hover={isHovered}
-                    onclick={() => jumpToCategory(s.slug)}
-                    onmouseenter={() => (hoveredCategory = s.slug)}
-                    onmouseleave={() => (hoveredCategory = null)}
-                    onfocus={() => (hoveredCategory = s.slug)}
-                    onblur={() => (hoveredCategory = null)}
-                    title={s.slug === "__other__" ? "Browse all in Discover" : `Browse ${s.label} in Discover`}
-                  >
-                    <span class="legend-dot" style="background: {s.color}"></span>
-                    <span class="legend-icon"><Icon size={12} /></span>
-                    <span class="legend-label truncate">{s.label}</span>
-                    <span class="legend-count">{fmt(s.count)}</span>
-                    <span class="legend-pct text-muted">{s.pct.toFixed(1)}%</span>
-                  </button>
-                </li>
-              {/each}
-            </ul>
           </div>
         </section>
       {/if}
@@ -930,6 +1008,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
+    /* Size container so the Composition/Categories pairing breakpoint tracks
+       the content-pane width (sidebar + inspector excluded) — the CSS analog
+       of native's onGeometryChange(>980) measurement. */
+    container-type: inline-size;
+    container-name: dash;
   }
   /* Flex children default to flex-shrink: 1, which causes the cards to be
      squashed to fit the viewport instead of overflowing the scroll container.
@@ -1132,7 +1215,6 @@
   .swatch { width: 10px; height: 10px; border-radius: 2px; }
   .swatch--formula { background: var(--color-info, #4a90e2); }
   .swatch--cask { background: var(--color-brand, #f59e0b); }
-  .meta-row { display: flex; gap: var(--space-2); flex-wrap: wrap; }
   .meta-pill {
     display: inline-flex;
     align-items: center;
@@ -1144,6 +1226,60 @@
     color: var(--color-text-secondary);
     font-size: var(--text-caption);
     font-weight: var(--fw-medium);
+  }
+
+  /* ─── Composition + Categories pairing ────────────────── */
+  /* Stacked full-width by default; two-across once the pane is wide enough
+     AND both cards are present (`paired`). When paired+wide, Composition
+     swaps its horizontal bar for a pie (rhymes with the categories donut). */
+  .dash-pair {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+  .comp-card { min-width: 0; }
+  /* on-request / pinned chips, right-aligned in the card header (the
+     .card-head is already a space-between flex row, so this pins right). */
+  .comp-chips { display: inline-flex; flex-wrap: wrap; gap: var(--space-2); }
+  .comp-bar { display: flex; flex-direction: column; gap: var(--space-3); }
+  .comp-pie { display: none; }
+
+  @container dash (min-width: 820px) {
+    /* stretch (grid default) so both cards share the taller card's height,
+       matching native's .frame(maxHeight: .infinity) bottom-alignment. */
+    .dash-pair.paired { grid-template-columns: 1fr 1fr; align-items: stretch; }
+    .dash-pair.paired .comp-bar { display: none; }
+    /* Cards become flex columns so each chart body fills the (equal) card
+       height, letting the chart sit vertically centered — like native, where
+       both 180×180 charts are center-aligned in equal-height cards. Centering
+       both same-size charts in equal bodies is what makes them line up. */
+    .dash-pair.paired > .card { display: flex; flex-direction: column; }
+    .dash-pair.paired .split { flex: 1; justify-content: center; }
+    .dash-pair.paired .donut-wrap { flex: 1; align-items: center; }
+    .dash-pair.paired .comp-pie {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: var(--space-4);
+      align-items: center;
+    }
+  }
+
+  /* Same diameter as the categories donut (180px) so the paired charts read
+     as a matched set, like native (both .frame(180×180)). */
+  .pie { width: 180px; height: 180px; flex-shrink: 0; }
+  .pie-legend { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .pie-legend li {
+    display: grid;
+    grid-template-columns: 10px minmax(0, 1fr) auto 48px;
+    gap: var(--space-2);
+    align-items: center;
+    padding: 4px var(--space-2);
+    font-size: var(--text-body-sm);
+  }
+  .pie-legend .legend-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* ─── Donut chart + legend ────────────────────────────── */
@@ -1158,7 +1294,7 @@
   .donut-track {
     fill: none;
     stroke: var(--color-surface-sunken);
-    stroke-width: 20;
+    stroke-width: 24;
   }
   .donut-legend { display: flex; flex-direction: column; gap: 4px; }
   .legend-row {

--- a/src/lib/components/Discover.svelte
+++ b/src/lib/components/Discover.svelte
@@ -5,6 +5,7 @@
   import Loader from "@lucide/svelte/icons/loader-2";
   import AlertTriangle from "@lucide/svelte/icons/alert-triangle";
   import Pill from "./Pill.svelte";
+  import PackageRowIcon from "./PackageRowIcon.svelte";
   import Input from "./Input.svelte";
   import LoadingState from "./LoadingState.svelte";
   import EmptyState from "./EmptyState.svelte";
@@ -254,11 +255,14 @@
               aria-current={isSelected ? "true" : undefined}
               onclick={() => openHit(h)}
             >
-              <span class="name truncate">
-                <span class="name-text">{h.name}</span>
-                {#if friendlyOf(h.name)}
-                  <span class="friendly-subtitle">{friendlyOf(h.name)}</span>
-                {/if}
+              <span class="name-cell">
+                <PackageRowIcon token={h.name} kind={h.kind} resolveCask />
+                <span class="name truncate">
+                  <span class="name-text">{h.name}</span>
+                  {#if friendlyOf(h.name)}
+                    <span class="friendly-subtitle">{friendlyOf(h.name)}</span>
+                  {/if}
+                </span>
               </span>
               <span class="desc truncate text-muted">{enrichment.summaryOf(h.name) ?? h.description ?? ""}</span>
               <span class="version truncate text-muted">{catalog.versionOf(h.name, h.kind) ?? ""}</span>
@@ -293,11 +297,14 @@
                 aria-current={isSelected ? "true" : undefined}
                 onclick={() => openHit(h)}
               >
-                <span class="name truncate">
-                  <span class="name-text">{h.name}</span>
-                  {#if friendlyOf(h.name)}
-                    <span class="friendly-subtitle">{friendlyOf(h.name)}</span>
-                  {/if}
+                <span class="name-cell">
+                  <PackageRowIcon token={h.name} kind={h.kind} resolveCask />
+                  <span class="name truncate">
+                    <span class="name-text">{h.name}</span>
+                    {#if friendlyOf(h.name)}
+                      <span class="friendly-subtitle">{friendlyOf(h.name)}</span>
+                    {/if}
+                  </span>
                 </span>
                 <span class="desc truncate text-muted">{descOf(h.name, h.kind) ?? ""}</span>
                 <span class="version truncate text-muted">{catalog.versionOf(h.name, h.kind) ?? ""}</span>
@@ -511,6 +518,15 @@
      for cross-pane consistency. Versions tend to be short (e.g. "1.25.0",
      "2026.01.07"), so 100px is comfortable. */
   .row--with-desc { grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) 100px 80px 90px; }
+  /* Icon + name stack share the first column; the icon sits left of the
+     name/friendly-subtitle stack (matches native's iconNameCell). */
+  .name-cell {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+    overflow: hidden;
+  }
   .row:hover { background: var(--color-surface-sunken); }
   .row.selected {
     background: var(--color-selection-strong);

--- a/src/lib/components/PackageDetail.svelte
+++ b/src/lib/components/PackageDetail.svelte
@@ -11,6 +11,7 @@
 
   import Pill from "./Pill.svelte";
   import Button from "./Button.svelte";
+  import PackageRowIcon from "./PackageRowIcon.svelte";
   import DestructiveConfirm from "./DestructiveConfirm.svelte";
   import InfoButton from "./InfoButton.svelte";
   import LoadingState from "./LoadingState.svelte";
@@ -878,6 +879,19 @@
           <Button variant="secondary" onclick={() => ui.selectedPackage && loadDetail(ui.selectedPackage.name, ui.selectedPackage.kind)}>Retry</Button>
         </div>
       {:else if detail && pkg}
+        <!-- Centered app-icon identity anchor (matches native's DetailIcon):
+             the resolved cask icon at 64px, or a kind glyph for formulae /
+             unresolved casks. Provenance still lives in the "Icon source"
+             meta row below. -->
+        <div class="detail-icon">
+          <PackageRowIcon
+            token={pkg.name}
+            kind={pkg.kind}
+            iconSource={pkg.iconSource}
+            homepage={pkg.homepage}
+            size={64}
+          />
+        </div>
         <dl class="meta">
           {#if enriched?.friendlyName}
             <!-- AI is on AND enrichment has a friendlyName, so the h1
@@ -1524,6 +1538,13 @@
 
   .close { color: var(--color-text-muted); padding: 4px; border-radius: var(--radius-sm); }
   .close:hover { background: var(--color-surface-sunken); color: var(--color-text-primary); }
+
+  /* Centered app-icon anchor at the top of the detail body. */
+  .detail-icon {
+    display: flex;
+    justify-content: center;
+    padding: var(--space-2) 0 var(--space-4);
+  }
 
   .body {
     padding: var(--space-4);

--- a/src/lib/components/PackageRow.svelte
+++ b/src/lib/components/PackageRow.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
-  import PackageIcon from "@lucide/svelte/icons/package";
   import Pill from "./Pill.svelte";
-  import { iconCache } from "$lib/stores/iconCache.svelte";
+  import PackageRowIcon from "./PackageRowIcon.svelte";
   import { enrichment } from "$lib/stores/enrichment.svelte";
   import { settings } from "$lib/stores/settings.svelte";
   import { vulnerabilities } from "$lib/stores/vulnerabilities.svelte";
@@ -80,40 +79,6 @@
     return enrichment.summaryOf(pkg.name) ?? pkg.description ?? null;
   }
 
-  // Per-row icon state. We keep this row-local rather than reading
-  // iconCache.cache directly so the row can reflect "loading" before the
-  // first resolve, and we don't recompute the Map lookup on every keystroke
-  // in the Library filter.
-  let iconDataUrl = $state<string | null>(null);
-  let iconLoaded = $state(false);
-
-  // Lazy-fetch on mount (and re-fetch if the row's pkg identity changes —
-  // happens when the Library list re-keys on filter swap).
-  //
-  // Phase 8: gating now lives inside iconCache via pkg.iconSource — formulae
-  // resolve to null immediately (iconSource.kind === "none") without an IPC
-  // hop, so we can drive both kinds through the same path and let the store
-  // route to cask_icon vs cask_icon_from_homepage. We still peek the cache
-  // first to avoid a microtask on the hot path.
-  $effect(() => {
-    const token = pkg.name;
-    // Synchronous peek first — avoids a microtask if cached.
-    const cached = iconCache.peek(token);
-    if (cached !== undefined) {
-      iconDataUrl = cached;
-      iconLoaded = true;
-      return;
-    }
-    iconLoaded = false;
-    iconDataUrl = null;
-    let canceled = false;
-    iconCache.getIcon(pkg).then((result) => {
-      if (canceled) return;
-      iconDataUrl = result;
-      iconLoaded = true;
-    });
-    return () => { canceled = true; };
-  });
 </script>
 
 <button
@@ -122,16 +87,7 @@
   aria-current={selected ? "true" : undefined}
   onclick={() => onSelect?.(pkg)}
 >
-  <span class="icon-slot" aria-hidden="true">
-    {#if iconDataUrl}
-      <img src={iconDataUrl} alt="" width="24" height="24" class="cask-icon" />
-    {:else if pkg.iconSource.kind !== "none" && iconLoaded}
-      <!-- tried, no icon — small neutral fallback so casks remain visually distinct from formulae -->
-      <PackageIcon size={18} class="fallback-icon" />
-    {/if}
-    <!-- packages with iconSource.kind === "none" (formulae, casks with no app + no homepage)
-         intentionally render an empty 24px slot so the name column stays aligned -->
-  </span>
+  <PackageRowIcon token={pkg.name} kind={pkg.kind} iconSource={pkg.iconSource} homepage={pkg.homepage} />
   <span class="name truncate" title={pkg.name}>
     <span class="name-text">{pkg.name}</span>
     {#if friendlyOf(pkg.name)}
@@ -220,31 +176,6 @@
   }
   .row.selected .version,
   .row.selected .upgrade { color: inherit; }
-
-  .icon-slot {
-    width: 24px;
-    height: 24px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    /* no transition / no fade-in — designSystem §6 says terminal-style instant for lists */
-  }
-  .cask-icon {
-    width: 24px;
-    height: 24px;
-    border-radius: 4px; /* matches macOS app-icon rounding-feel without faking the squircle */
-    object-fit: contain;
-    display: block;
-  }
-  .row :global(.fallback-icon) {
-    color: var(--color-text-muted);
-    opacity: 0.6;
-  }
-  .row.selected :global(.fallback-icon) {
-    color: var(--color-text-inverse);
-    opacity: 0.7;
-  }
 
   /* Vertical flex container so the optional AI-enriched friendly_name
      subtitle (Phase 13) stacks below the raw token. Children manage

--- a/src/lib/components/PackageRowIcon.svelte
+++ b/src/lib/components/PackageRowIcon.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  // Shared package icon for every list view + the detail header — the Tauri
+  // analog of native's `PackageIcon`/`DetailIcon`. Renders, in priority order:
+  //   1. the resolved app icon (casks: Appcasks → homepage-favicon cascade)
+  //   2. a kind glyph fallback — `terminal` for formulae (CLI tools, no app
+  //      icon), `square-dashed` for casks we tried but couldn't resolve.
+  // Formulae never hit the backend (they have no app icon); the terminal glyph
+  // is the identity. Casks resolve via the shared `iconCache` (token-keyed,
+  // session-memoized, backend disk-cached). `homepage`/`resolveCask` only
+  // matter for the favicon fallback when the caller doesn't already carry a
+  // resolved `iconSource` (Library does; Discover/Trending don't).
+  import Terminal from "@lucide/svelte/icons/terminal";
+  import SquareDashed from "@lucide/svelte/icons/square-dashed";
+  import { iconCache } from "$lib/stores/iconCache.svelte";
+  import { catalog } from "$lib/stores/catalog.svelte";
+  import type { IconSource, Package, PackageKind } from "$lib/types";
+
+  interface Props {
+    token: string;
+    kind: PackageKind;
+    /** Known icon source (Library rows carry this from the full Package). */
+    iconSource?: IconSource;
+    /** Known homepage for the favicon fallback (when iconSource is absent). */
+    homepage?: string | null;
+    /** When true and neither iconSource nor homepage is given, look the cask
+        up in the catalog to recover its homepage (Discover search hits). */
+    resolveCask?: boolean;
+    size?: number;
+  }
+
+  let { token, kind, iconSource, homepage, resolveCask = false, size = 24 }: Props =
+    $props();
+
+  // Larger icons (detail header) get a macOS-app-flavoured rounding; small
+  // list icons stay subtly rounded. Mirrors native's cornerRadius 14 @ 64pt.
+  const radius = $derived(size >= 48 ? 14 : 4);
+  const glyphSize = $derived(Math.max(12, Math.round(size * (size >= 48 ? 0.7 : 0.72))));
+
+  let dataUrl = $state<string | null>(null);
+  let loaded = $state(false);
+
+  $effect(() => {
+    // Formulae: no app icon — the terminal glyph IS the icon. No backend hop.
+    if (kind === "formula") {
+      dataUrl = null;
+      loaded = true;
+      return;
+    }
+
+    // Cask — peek the session cache synchronously to avoid a microtask.
+    const peeked = iconCache.peek(token);
+    if (peeked !== undefined) {
+      dataUrl = peeked;
+      loaded = true;
+      return;
+    }
+
+    loaded = false;
+    dataUrl = null;
+    let canceled = false;
+
+    (async () => {
+      let src: IconSource | null = iconSource ?? null;
+      if (!src) {
+        if (homepage) {
+          src = { kind: "homepage", homepage };
+        } else if (resolveCask) {
+          const c = await catalog.lookupCask(token);
+          src = c?.homepage ? { kind: "homepage", homepage: c.homepage } : { kind: "none" };
+        } else {
+          src = { kind: "none" };
+        }
+      }
+      if (canceled) return;
+      // getIcon only reads `.name` + `.iconSource`; a minimal object is enough.
+      const result = await iconCache.getIcon({ name: token, iconSource: src } as unknown as Package);
+      if (canceled) return;
+      dataUrl = result;
+      loaded = true;
+    })();
+
+    return () => {
+      canceled = true;
+    };
+  });
+</script>
+
+<span class="pri-slot" style="width: {size}px; height: {size}px" aria-hidden="true">
+  {#if dataUrl}
+    <img src={dataUrl} alt="" width={size} height={size} class="pri-icon" style="border-radius: {radius}px" />
+  {:else if kind === "formula"}
+    <span class="pri-glyph"><Terminal size={glyphSize} /></span>
+  {:else if loaded}
+    <span class="pri-glyph"><SquareDashed size={glyphSize} /></span>
+  {/if}
+  <!-- cask still resolving: empty slot keeps the name column aligned -->
+</span>
+
+<style>
+  .pri-slot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    /* designSystem §6: list icons render instant, no fade-in */
+  }
+  .pri-icon {
+    object-fit: contain;
+    display: block;
+  }
+  /* Glyph inherits the row's currentColor (so it tints with selection) and
+     just dims via opacity — no hard-coded color to fight the selected state. */
+  .pri-glyph {
+    display: inline-flex;
+    opacity: 0.55;
+  }
+</style>

--- a/src/lib/components/Trending.svelte
+++ b/src/lib/components/Trending.svelte
@@ -7,6 +7,7 @@
 
   import Button from "./Button.svelte";
   import Pill from "./Pill.svelte";
+  import PackageRowIcon from "./PackageRowIcon.svelte";
   import LoadingState from "./LoadingState.svelte";
   import EmptyState from "./EmptyState.svelte";
   import SortableHeader from "./SortableHeader.svelte";
@@ -52,12 +53,13 @@
     return fallback ?? null;
   }
 
-  /** Velocity tier classification for the badge: >=1.5 surging,
-      <=0.5 cooling, otherwise neutral. */
+  /** Velocity tier classification for the badge, matching velocity_index's
+      documented semantics (1.0 ≈ steady): >=1.5 surging, <=0.7 cooling,
+      otherwise neutral. Canonical rule shared with the native build. */
   function velocityTier(v: number | null): "surge" | "cool" | "neutral" | "none" {
     if (v === null) return "none";
     if (v >= 1.5) return "surge";
-    if (v <= 0.5) return "cool";
+    if (v <= 0.7) return "cool";
     return "neutral";
   }
 
@@ -183,11 +185,14 @@
               onclick={() => openEntry(e.name, e.kind)}
             >
               <span class="rank">{e.rank}</span>
-              <span class="name truncate">
-                <span class="name-text">{e.name}</span>
-                {#if friendlyOf(e.name)}
-                  <span class="friendly-subtitle">{friendlyOf(e.name)}</span>
-                {/if}
+              <span class="name-cell">
+                <PackageRowIcon token={e.name} kind={e.kind} resolveCask />
+                <span class="name truncate">
+                  <span class="name-text">{e.name}</span>
+                  {#if friendlyOf(e.name)}
+                    <span class="friendly-subtitle">{friendlyOf(e.name)}</span>
+                  {/if}
+                </span>
               </span>
               <span class="desc truncate text-muted">{enrichment.summaryOf(e.name) ?? catalog.descOf(e.name, e.kind) ?? ""}</span>
               <span class="version truncate text-muted">{catalog.versionOf(e.name, e.kind) ?? ""}</span>
@@ -349,6 +354,14 @@
     border-bottom: 1px solid var(--color-border);
   }
   .row:hover { background: var(--color-surface-sunken); }
+  /* Icon + name stack share the name column (matches native's iconNameCell). */
+  .name-cell {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+    overflow: hidden;
+  }
   .row.selected {
     background: var(--color-selection-strong);
     color: var(--color-text-inverse);


### PR DESCRIPTION
Brings the shipped Tauri app up to the native macOS rebuild's treatment in the areas where it had pulled ahead. Frontend Svelte + one Rust change; no data-contract changes. Branch is rooted on \`main\`, so this is a clean diff.

## What's in it
- **Shared \`PackageRowIcon\`** — Tauri analog of native's \`PackageIcon\` (resolved cask icon → \`terminal\` glyph for formulae → \`square-dashed\` for unresolved casks). **Discover + Trending had no list icons; added.** Library routed through it.
- **Detail panel** — centered 64px app icon at the top of the body (keeps the shared \`.panel-head\` alignment).
- **Dashboard** — Composition pie + Top-categories paired side-by-side on wide panes (container query); chips moved into the card header; equal-height cards; charts matched to native specs (outer radius 60, donut inner ratio 0.6, filled \`<path>\` pie, vertical centering, opacity-only donut hover).
- **Keychain → one prompt** — \`auth.rs\` batches the GitHub status read into a single \`SecItemCopyMatching(kSecMatchLimitAll)\` via \`security-framework\`, mirroring native's \`keychainReadAll\` (was three reads = three prompts).
- **Trending velocity badge** — canonical formula-faithful banded threshold: ≥1.5 🔥 / ≤0.7 ❄️ / neutral.

## Verification
- \`npm run check\`: 0 errors
- Rust compiles clean via \`tauri dev\`
- Confirmed visually via screenshots

## Docs
- \`memory-bank/tasks/2026-06/01-tauri-native-parity.md\`
- \`memory-bank/decisions.md#2026-06-02\`

Reverse-parity (native←Tauri: legend icons, banded velocity, Snapshots/Services) is tracked separately and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)