### PR TITLE
refactor(pipeline): rsync deploy model (drop git-from-host)

### DIFF
--- a/tools/pipeline/README.md
+++ b/tools/pipeline/README.md
@@ -3,52 +3,59 @@
 Build-time tooling. Regenerates the AI **categories** + **descriptions** nightly
 and renders the static tree the app fetches for **opt-in live updates**.
 
-This never runs from inside the app. It runs on a build host, on a schedule.
+Deployed as a **copy** (rsync), like `tools/trending-collector` — no git on the
+host, no data committed back from the host. Same model as trending: the served
+tree is the delivery mechanism; the app fetches it live.
 
 ## What it does (`nightly-refresh.sh`)
 
-1. `git reset --hard origin/main` — sync the regeneration logic.
-2. `tools/catalog/fetch.py` — refresh the Homebrew catalog.
-3. `tools/categorize/categorize.py` — incremental category pass → `src-tauri/data/categories.json`.
-4. `tools/enrich/enrich.py --tier-a` — incremental description pass → `src-tauri/data/enrichment.json.gz`.
-5. `tools/pipeline/render_served.py` — render `$OUT_DIR/{version.json, categories.json, entry/<token>.json}` for live fetch.
-6. Force-push the data delta to `data/auto-refresh` (always "current main + latest data"; merge it when cutting a release so the *bundled* baseline stays current too).
+1. `tools/catalog/fetch.py` — refresh the Homebrew catalog.
+2. `tools/categorize/categorize.py` — incremental category pass → `src-tauri/data/categories.json`.
+3. `tools/enrich/enrich.py --tier-a` — incremental description pass → `src-tauri/data/enrichment.json.gz`.
+4. `tools/pipeline/render_served.py` — render `$OUT_DIR/{version.json, categories.json, entry/<token>.json}`.
 
-All three LLM/catalog steps are diff-aware (their own `state/`), so a typical
-night hits the API for only the handful of packages that changed.
+Each regen step is diff-aware (its own `state/`), so a typical night hits the
+API for only the handful of packages that changed.
+
+The repo's **bundled baseline** (`src-tauri/data/*`) is refreshed *manually at
+release time*: run this pipeline locally and `git commit src-tauri/data`. Live
+fetch covers day-to-day freshness for opted-in users between releases.
 
 ## Configuration (env vars — no private host/paths in this repo)
 
 | Var | Default | Meaning |
 |-----|---------|---------|
-| `REPO_DIR` | the repo this script lives in | brew-browser clone |
-| `OUT_DIR` | `$REPO_DIR/tools/pipeline/out` | served render target (point at the web-served dir) |
-| `DATA_BRANCH` | `data/auto-refresh` | branch the regenerated data is force-pushed to |
-| `PYTHON` | `$REPO_DIR/.venv/bin/python` | interpreter |
+| `TOOL_DIR` | 2 levels up from the script | the deployed copy holding `tools/` + `src-tauri/data/` |
+| `OUT_DIR` | `$TOOL_DIR/tools/pipeline/out` | served render target (point at the web-served dir) |
+| `PYTHON` | `$TOOL_DIR/.venv/bin/python` | interpreter |
 | `ENRICH_FLAGS` | `--tier-a` | enrich tiers to run |
 
-## Deploy (generic — substitute your own host/paths)
+## Deploy (rsync a minimal copy — substitute your own host/paths)
 
 ```sh
-# On the build host, as the deploy user:
-git clone https://github.com/msitarzewski/brew-browser.git "$REPO_DIR"
-cd "$REPO_DIR"
+# From a repo checkout, rsync only what the pipeline needs to the host:
+TOOL_DIR=<host>:/path/to/tools/brew-browser/enrichment
+rsync -az --delete tools/ "$TOOL_DIR/tools/"
+rsync -az --delete src-tauri/data/ "$TOOL_DIR/src-tauri/data/"   # seed + working data
+
+# On the host, once:
+cd "$TOOL_DIR_LOCAL"
 python3 -m venv .venv
 .venv/bin/pip install -r tools/categorize/requirements.txt -r tools/enrich/requirements.txt
-
-# Anthropic key — one key serves categorize + enrich. .env is gitignored.
-cp tools/enrich/.env.example tools/enrich/.env   # then paste ANTHROPIC_API_KEY
+cp tools/enrich/.env.example tools/enrich/.env          # paste ANTHROPIC_API_KEY
 cp tools/categorize/.env.example tools/categorize/.env  # same key
 
 # First run (full bulk — minutes, a few $). Subsequent runs are incremental.
-OUT_DIR="$OUT_DIR" .venv/bin/... # see nightly-refresh.sh; or just:
-OUT_DIR="$OUT_DIR" REPO_DIR="$REPO_DIR" tools/pipeline/nightly-refresh.sh
+TOOL_DIR="$TOOL_DIR_LOCAL" OUT_DIR="$OUT_DIR" tools/pipeline/nightly-refresh.sh
 ```
 
-### Cron (run after the trending collector settles)
+Re-rsync `tools/` whenever the pipeline code changes (the host copy is not a
+git checkout — it doesn't pull).
+
+### Cron (after the trending collector settles)
 
 ```cron
-30 3 * * * REPO_DIR="$REPO_DIR" OUT_DIR="$OUT_DIR" "$REPO_DIR/tools/pipeline/nightly-refresh.sh" >> "$LOGFILE" 2>&1
+30 3 * * * TOOL_DIR="$TOOL_DIR" OUT_DIR="$OUT_DIR" "$TOOL_DIR/tools/pipeline/nightly-refresh.sh" >> "$LOGFILE" 2>&1
 ```
 
 ### Caddy (serve `$OUT_DIR` at `…/enrichment/*`)

--- a/tools/pipeline/nightly-refresh.sh
+++ b/tools/pipeline/nightly-refresh.sh
@@ -2,58 +2,32 @@
 # Nightly regeneration of brew-browser's AI categories + descriptions, and the
 # static tree served for the app's opt-in *live* updates.
 #
-# Transparent + committed. This script hard-codes NO private hostnames or paths
-# — everything host-specific comes from env vars. Deploy guide: see README.md.
+# Deployed as a COPY (rsync), like the trending collector — there is NO git in
+# this script. The rendered tree (render_served.py -> $OUT_DIR) IS the delivery
+# mechanism; the app fetches it live. The repo's *bundled* baseline is refreshed
+# manually at release time (run this locally, then commit src-tauri/data).
 #
-#   REPO_DIR     path to the brew-browser clone   (default: the repo this lives in)
-#   OUT_DIR      served output dir (render target) (default: $REPO_DIR/tools/pipeline/out)
-#   DATA_BRANCH  branch the regenerated data is force-pushed to (default: data/auto-refresh)
-#   PYTHON       python interpreter               (default: $REPO_DIR/.venv/bin/python)
-#   ENRICH_FLAGS enrich.py tier flags             (default: --tier-a)
+#   TOOL_DIR     dir holding tools/ + src-tauri/data/  (default: 2 levels up from this script)
+#   OUT_DIR      served output dir (render target)     (default: $TOOL_DIR/tools/pipeline/out)
+#   PYTHON       interpreter                            (default: $TOOL_DIR/.venv/bin/python)
+#   ENRICH_FLAGS enrich.py tier flags                   (default: --tier-a)
 #
-# Idempotent + no-ops cleanly when nothing changed. Exits non-zero on hard error.
+# Each regen step is incremental (diff-aware via its own tools/*/state). Exits
+# non-zero on hard error.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
-DATA_BRANCH="${DATA_BRANCH:-data/auto-refresh}"
-PYTHON="${PYTHON:-$REPO_DIR/.venv/bin/python}"
+TOOL_DIR="${TOOL_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+PYTHON="${PYTHON:-$TOOL_DIR/.venv/bin/python}"
 ENRICH_FLAGS="${ENRICH_FLAGS:---tier-a}"
-export OUT_DIR="${OUT_DIR:-$REPO_DIR/tools/pipeline/out}"
+export OUT_DIR="${OUT_DIR:-$TOOL_DIR/tools/pipeline/out}"
 
-cd "$REPO_DIR"
+cd "$TOOL_DIR"
 log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*"; }
 
-log "=== nightly-refresh start (repo=$REPO_DIR out=$OUT_DIR branch=$DATA_BRANCH) ==="
-
-# 1. Sync regeneration logic from main (keep tools current). Reset is safe:
-#    runtime state (tools/*/state, .venv, .env) is gitignored + untracked, so
-#    a hard reset of tracked files leaves the incremental-diff state intact.
-git fetch --quiet origin
-git checkout --quiet main
-git reset --hard --quiet origin/main
-
-# 2. Regenerate data — each step is incremental (diff-aware via its own state/).
+log "=== nightly-refresh start (tool=$TOOL_DIR out=$OUT_DIR) ==="
 log "catalog fetch…";          "$PYTHON" tools/catalog/fetch.py
 log "categorize…";             "$PYTHON" tools/categorize/categorize.py
 log "enrich ($ENRICH_FLAGS)…"; "$PYTHON" tools/enrich/enrich.py $ENRICH_FLAGS
-
-# 3. Render the served tree from the FRESH data (before the reset in step 4).
-log "render served…"
-"$PYTHON" tools/pipeline/render_served.py
-
-# 4. Force-push the data delta to DATA_BRANCH (= current main + latest data, so
-#    it's always cleanly mergeable at release), then reset local main clean so
-#    the next run fast-forwards. The data commit lives only on the remote branch.
-git add src-tauri/data
-if git diff --cached --quiet; then
-  log "no data changes — skipping commit"
-else
-  git -c user.name="brew-browser-bot" -c user.email="bot@users.noreply.github.com" \
-      commit --quiet -m "chore(data): nightly categorize+enrich refresh $(date -u +%F)"
-  git push --force --quiet origin "HEAD:$DATA_BRANCH"
-  log "pushed data delta -> $DATA_BRANCH"
-  git reset --hard --quiet origin/main
-fi
-
+log "render served…";          "$PYTHON" tools/pipeline/render_served.py
 log "=== nightly-refresh done ==="


### PR DESCRIPTION
Simplify the nightly pipeline to match how the trending collector is deployed: a plain regenerate->render with no git on the host. The served tree is the delivery mechanism; the bundled baseline is refreshed manually at release.

- nightly-refresh.sh: removed git pull/commit/push; pure catalog/categorize/enrich/render. TOOL_DIR replaces REPO_DIR.
- README: rsync deploy guide (minimal copy under ~/tools/..., no clone, no data branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)