### PR TITLE
fix(tauri): Trending parity with native — tap tokens, velocity, refresh feedback

### DIFF
--- a/memory-bank/tasks/2026-06/02-tauri-trending-tap-tokens.md
+++ b/memory-bank/tasks/2026-06/02-tauri-trending-tap-tokens.md
@@ -1,0 +1,81 @@
+# 02 — Tauri trending tap-token resolution (native parity)
+
+**Date:** 2026-06-04
+**Branch:** `fix/tauri-trending-tap-tokens` (off `main`)
+
+## Objective
+
+Port the native build's tap-token fix (`experiment` task 02) to the shipped
+Tauri app. Third-party **tap** packages in Trending (e.g.
+`anomalyco/tap/opencode`) rendered with no friendly name / summary / version and
+errored on detail open.
+
+## Root cause (identical to native)
+
+Homebrew install-analytics report tap formulae fully-qualified as
+`user/tap/name`, but the bundled catalog + enrichment are keyed by the **bare**
+name. `Trending.svelte` feeds the qualified `e.name` into:
+
+- `enrichment.lookup()` → `entries[token]` (bare key) → null → no friendly
+  name / summary.
+- `catalog.descOf` / `versionOf` → `map.get(name)` (bare key) → null → blank
+  desc + version.
+- `PackageDetail.loadDetail` → `brewInfo(name)` → fails when the tap isn't
+  tapped locally ("requires the tap …").
+
+## Outcome
+
+- ✅ `npm run check` clean (0 errors; 3 pre-existing unrelated warnings).
+
+## Changes
+
+- **`src/lib/util/token.ts`** (new) — `bareToken()`; mirrors native
+  `AppModel.bareToken(_:)`.
+- **`src/lib/stores/enrichment.svelte.ts`** — `lookup()` bare-name fallback
+  (also fixes `friendlyName`, `summaryOf`, and `PackageDetail`'s `enriched`),
+  composed with PR #43's live overlay (live → bundled → bare live → bare
+  bundled). `ensureLive()` also fetches/dedupes/keys by the bare name so tap
+  rows get live refresh too (mirrors native `ensureLiveEnrichment`).
+- **`src/lib/stores/catalog.svelte.ts`** — `descOf` / `versionOf` bare-name
+  fallback.
+- **`src/lib/components/PackageDetail.svelte`** — `loadDetail` retries
+  `brewInfo(bareToken(name))` when the qualified name fails.
+
+All fallback-only (exact match wins first), so normal packages are unaffected.
+
+## Velocity leaderboard parity (the bigger fix)
+
+Comparing the two Trending lists revealed a material data divergence: native
+surfaced high-velocity rising packages (nbytes 9.60, simdutf 4.33, opencode
+4.04, llhttp 3.38, …) that Tauri omitted entirely.
+
+**Root cause** — `commands/trending.rs:build_velocity_map` built `c30/c90/c365`
+from each window's **cached report entries**, which `client::merge_entries`
+already truncated to **top-100 by installs**. So velocity was only computable
+for packages in the top-100 of *all three* windows. A rising package (top-100
+in 30d but ranked >100 over 365d) had no `c365` → no velocity → dropped from the
+leaderboard. Native computes velocity from the **full, uncapped** per-window
+maps and caps only the display.
+
+**Fix** — carry the full uncapped `name→install_count` map per window:
+- `trending/client.rs` — `fetch()` now returns `(TrendingReport, HashMap<String,u64>)`;
+  the map is built from `install.items` before `merge_entries` truncates.
+- `trending/cache.rs` — `CachedTrending` gains `full_counts`.
+- `commands/trending.rs` — `ensure_all_windows_cached` stores `full_counts`;
+  `build_velocity_map` joins over them instead of the capped report entries.
+
+`cargo build` clean; `cargo test trending` → 58 passed. Requires a backend
+rebuild (`npm run tauri dev` recompiles Rust; HMR alone won't pick it up).
+
+## Refresh feedback
+
+`Trending.svelte` Refresh button now passes `loading={trending.loading}` to the
+shared `Button` (spins + disables while refetching) — it previously gave no
+visual feedback.
+
+## Parity
+
+Brings Tauri to parity with native commit `efd45d1`
+(`experiment` task `02-native-trending-tap-tokens-and-refresh-feedback`):
+tap-token resolution, Refresh feedback, and — beyond the native commit — the
+velocity leaderboard now matches native's full-map computation.

--- a/memory-bank/tasks/2026-06/README.md
+++ b/memory-bank/tasks/2026-06/README.md
@@ -7,6 +7,7 @@ Per-task records for June 2026 work on brew-browser.
 | # | Task | Date | Branch | Release |
 |---|---|---|---|---|
 | 01 | [Tauri←native feature parity (icons, Dashboard charts, keychain one-prompt, velocity threshold)](./01-tauri-native-parity.md) | 2026-06-02 | `tauri-parity` | — |
+| 02 | [Tauri trending tap-token resolution (native parity)](./02-tauri-trending-tap-tokens.md) | 2026-06-04 | `fix/tauri-trending-tap-tokens` | — |
 
 ## Context
 

--- a/src-tauri/src/commands/trending.rs
+++ b/src-tauri/src/commands/trending.rs
@@ -140,13 +140,13 @@ async fn ensure_all_windows_cached(
     // JoinSet (vs. `futures::future::join_all`) keeps us on the
     // tokio-only dependency footprint and lets each task be cancelled
     // independently if a future need arose.
-    let mut set: tokio::task::JoinSet<(TrendingWindow, Result<TrendingReport, BrewError>)> =
-        tokio::task::JoinSet::new();
+    type WindowFetch = Result<(TrendingReport, HashMap<String, u64>), BrewError>;
+    let mut set: tokio::task::JoinSet<(TrendingWindow, WindowFetch)> = tokio::task::JoinSet::new();
     for w in stale {
         let installed_owned: HashSet<String> = installed.clone();
         set.spawn(async move { (w, client::fetch(w, &installed_owned).await) });
     }
-    let mut results: Vec<(TrendingWindow, Result<TrendingReport, BrewError>)> = Vec::new();
+    let mut results: Vec<(TrendingWindow, WindowFetch)> = Vec::new();
     while let Some(joined) = set.join_next().await {
         match joined {
             Ok(pair) => results.push(pair),
@@ -160,11 +160,12 @@ async fn ensure_all_windows_cached(
     let mut cache = state.trending_cache.lock().await;
     for (w, res) in results {
         match res {
-            Ok(report) => cache.put(
+            Ok((report, full_counts)) => cache.put(
                 w,
                 CachedTrending {
                     fetched_at: Instant::now(),
                     report,
+                    full_counts,
                 },
             ),
             Err(e) => {
@@ -186,16 +187,14 @@ async fn ensure_all_windows_cached(
 async fn build_velocity_map(state: &AppState) -> HashMap<String, Option<f64>> {
     let cache = state.trending_cache.lock().await;
 
+    // Use each window's FULL (uncapped) install-count map, not the top-100
+    // display entries — otherwise a package that's top-100 in 30d but not over
+    // 365d has no c365 here and silently loses its velocity (dropping rising
+    // packages from the leaderboard). Mirrors native's full-map computation.
     let extract = |w: TrendingWindow| -> HashMap<String, u64> {
         cache
             .get(w)
-            .map(|c| {
-                c.report
-                    .entries
-                    .iter()
-                    .map(|e| (e.name.clone(), e.install_count))
-                    .collect()
-            })
+            .map(|c| c.full_counts.clone())
             .unwrap_or_default()
     };
 
@@ -412,6 +411,7 @@ mod tests {
                     total_count: 0,
                     entries: Vec::new(),
                 },
+                full_counts: Default::default(),
             },
         );
 

--- a/src-tauri/src/trending/cache.rs
+++ b/src-tauri/src/trending/cache.rs
@@ -19,6 +19,10 @@ pub struct TrendingCache {
 pub struct CachedTrending {
     pub fetched_at: Instant,
     pub report: TrendingReport,
+    /// Full, uncapped name→install_count for this window (all formulae, not
+    /// just the top-100 display set). Powers cross-window velocity so rising
+    /// packages aren't dropped. See `commands::trending::build_velocity_map`.
+    pub full_counts: std::collections::HashMap<String, u64>,
 }
 
 impl TrendingCache {
@@ -73,6 +77,7 @@ mod tests {
         CachedTrending {
             fetched_at: Instant::now() - age,
             report: make_report(window),
+            full_counts: std::collections::HashMap::new(),
         }
     }
 

--- a/src-tauri/src/trending/client.rs
+++ b/src-tauri/src/trending/client.rs
@@ -70,7 +70,7 @@ struct RawAnalyticsItem {
 pub async fn fetch(
     window: TrendingWindow,
     installed: &HashSet<String>,
-) -> Result<TrendingReport, BrewError> {
+) -> Result<(TrendingReport, HashMap<String, u64>), BrewError> {
     let client = build_client()?;
 
     // Fire both fetches concurrently. tokio::join! waits for both;
@@ -99,15 +99,30 @@ pub async fn fetch(
         }
     };
 
+    // Full, uncapped name→install_count for this window — feeds the cross-
+    // window velocity computation so rising packages (top-100 in 30d but
+    // ranked >100 over 365d) still get a velocity, matching the native build.
+    // The displayed report below stays capped to the top 100 by installs.
+    let full_counts: HashMap<String, u64> = install
+        .items
+        .iter()
+        .filter(|i| !i.formula.is_empty())
+        .map(|i| (i.formula.clone(), parse_count(&i.count)))
+        .collect();
+
+    let total_count = install.total_count;
     let entries = merge_entries(install.items, ior_map, installed);
 
-    Ok(TrendingReport {
-        window,
-        fetched_at: Utc::now().to_rfc3339(),
-        cache_age_seconds: 0,
-        total_count: install.total_count,
-        entries,
-    })
+    Ok((
+        TrendingReport {
+            window,
+            fetched_at: Utc::now().to_rfc3339(),
+            cache_age_seconds: 0,
+            total_count,
+            entries,
+        },
+        full_counts,
+    ))
 }
 
 /// v0.4.0 — pure merge of the two endpoint payloads into the final

--- a/src/lib/components/PackageDetail.svelte
+++ b/src/lib/components/PackageDetail.svelte
@@ -46,6 +46,7 @@
   import Shield from "@lucide/svelte/icons/shield";
   import { brewInfo, brewInstall, brewUninstall, brewUpgrade, appVersion } from "$lib/api";
   import { safeOpenUrl } from "$lib/util/url";
+  import { bareToken } from "$lib/util/token";
   import { reportableToastError } from "$lib/util/reportIssue";
   import { resolveCategoryIcon } from "$lib/util/categoryIcon";
   import IssueModal from "./IssueModal.svelte";
@@ -124,7 +125,19 @@
     try {
       detail = await brewInfo(name, kind);
     } catch (e) {
-      error = isBrewError(e) ? brewErrorMessage(e) : `Backend not available: ${String(e)}`;
+      // A tap-qualified name (`user/tap/name`) that isn't tapped locally makes
+      // `brew info` fail. Retry the bare name — the core formula the list's
+      // catalog/enrichment data already resolved to.
+      const bare = bareToken(name);
+      if (bare !== name) {
+        try {
+          detail = await brewInfo(bare, kind);
+        } catch {
+          error = isBrewError(e) ? brewErrorMessage(e) : `Backend not available: ${String(e)}`;
+        }
+      } else {
+        error = isBrewError(e) ? brewErrorMessage(e) : `Backend not available: ${String(e)}`;
+      }
     } finally {
       loading = false;
     }

--- a/src/lib/components/Trending.svelte
+++ b/src/lib/components/Trending.svelte
@@ -139,7 +139,7 @@
       </div>
       <span class="ago text-muted">{agoLabel}</span>
       <span class="refresh-wrap">
-        <Button size="sm" variant="ghost" onclick={() => trending.load(true)} title="Refresh (⌘R)" ariaLabel="Refresh trending">
+        <Button size="sm" variant="ghost" loading={trending.loading} onclick={() => trending.load(true)} title="Refresh (⌘R)" ariaLabel="Refresh trending">
           {#snippet icon()}<RefreshCw size={14} />{/snippet}
           Refresh
         </Button>

--- a/src/lib/stores/catalog.svelte.ts
+++ b/src/lib/stores/catalog.svelte.ts
@@ -23,6 +23,7 @@ import {
   catalogSummary,
 } from "$lib/api";
 import { settings } from "$lib/stores/settings.svelte";
+import { bareToken } from "$lib/util/token";
 import {
   brewErrorMessage,
   isBrewError,
@@ -184,7 +185,7 @@ class CatalogStore {
    */
   descOf(name: string, kind: PackageKind): string | null {
     const map = kind === "formula" ? this.descByFormula : this.descByCask;
-    return map?.get(name) ?? null;
+    return map?.get(name) ?? map?.get(bareToken(name)) ?? null;
   }
 
   /**
@@ -199,7 +200,7 @@ class CatalogStore {
    */
   versionOf(name: string, kind: PackageKind): string | null {
     const map = kind === "formula" ? this.versionByFormula : this.versionByCask;
-    return map?.get(name) ?? null;
+    return map?.get(name) ?? map?.get(bareToken(name)) ?? null;
   }
 
   /** Convenience wrapper around `catalog_lookup_formula`. Returns `null`

--- a/src/lib/stores/enrichment.svelte.ts
+++ b/src/lib/stores/enrichment.svelte.ts
@@ -14,6 +14,7 @@
 
 import { enrichmentData, enrichmentLiveEntry } from "$lib/api";
 import { settings } from "$lib/stores/settings.svelte";
+import { bareToken } from "$lib/util/token";
 import type { EnrichmentData, EnrichmentEntry } from "$lib/types";
 
 class EnrichmentStore {
@@ -57,8 +58,14 @@ class EnrichmentStore {
    */
   lookup(token: string): EnrichmentEntry | null {
     if (!settings.effective.aiFeaturesEnabled) return null;
-    // Live overlay wins over the bundled baseline; fall back to bundled, then null.
-    return this.liveEntries[token] ?? this.data?.entries[token] ?? null;
+    // Live overlay wins over the bundled baseline.
+    const hit = this.liveEntries[token] ?? this.data?.entries[token];
+    if (hit) return hit;
+    // Tap-qualified token (`user/tap/name`) → retry the bare name the
+    // enrichment is keyed by (live overlay still preferred over bundled).
+    const bare = bareToken(token);
+    if (bare === token) return null;
+    return this.liveEntries[bare] ?? this.data?.entries[bare] ?? null;
   }
 
   /** Friendly-name short-circuit: returns `friendlyName` if available AND
@@ -105,11 +112,15 @@ class EnrichmentStore {
    *  is normal and leaves the bundled entry in place. */
   async ensureLive(token: string): Promise<void> {
     if (!this.liveAllowed) return;
-    if (this.liveAttempted.has(token)) return;
-    this.liveAttempted.add(token);
+    // Tap-qualified tokens (`user/tap/name`) carry a `/` the served path +
+    // allowlist reject; fetch, dedupe, and key by the bare name — matching
+    // `lookup`'s bare fallback and the native build's `ensureLiveEnrichment`.
+    const key = bareToken(token);
+    if (this.liveAttempted.has(key)) return;
+    this.liveAttempted.add(key);
     try {
-      const entry = await enrichmentLiveEntry(token);
-      this.liveEntries = { ...this.liveEntries, [token]: entry };
+      const entry = await enrichmentLiveEntry(key);
+      this.liveEntries = { ...this.liveEntries, [key]: entry };
     } catch {
       // keep bundled
     }

--- a/src/lib/util/token.ts
+++ b/src/lib/util/token.ts
@@ -1,0 +1,14 @@
+/**
+ * Token normalization for Homebrew package identifiers.
+ *
+ * Homebrew install-analytics (the Trending data source) report tap formulae
+ * **fully-qualified** as `user/tap/name`, but the bundled catalog + enrichment
+ * are keyed by the **bare** name (`name`). Lookups that receive a qualified
+ * token must fall back to the bare name. Bare tokens pass through unchanged.
+ *
+ * Mirrors the native build's `AppModel.bareToken(_:)`.
+ */
+export function bareToken(token: string): string {
+  const slash = token.lastIndexOf("/");
+  return slash >= 0 ? token.slice(slash + 1) : token;
+}


### PR DESCRIPTION
Brings the shipped Tauri Trending tab to parity with the native build. Three fixes:

## 1. Tap-qualified tokens
Homebrew analytics report tap formulae as `user/tap/name`, but the bundled catalog + enrichment are keyed by the **bare** name. Tap rows (e.g. `anomalyco/tap/opencode`) showed no friendly name / summary / version and errored on detail open.

- `src/lib/util/token.ts` (new) — `bareToken()`
- `enrichment.lookup`, `catalog.descOf`/`versionOf` — bare-name **fallback** (exact match wins first)
- `PackageDetail.loadDetail` — retries `brewInfo(bare)` when the qualified tap name isn't tapped locally

## 2. Velocity leaderboard (the material divergence)
`build_velocity_map` joined `c30/c90/c365` from each window's **top-100-capped** report entries, so a rising package (top-100 in 30d but ranked >100 over 365d) had no `c365` → no velocity → **dropped from the leaderboard**. Native computes velocity from the **full, uncapped** per-window maps and caps only the display.

- `trending/client.rs` — `fetch()` returns `(TrendingReport, HashMap<String,u64>)` (full uncapped map, built before the top-100 truncation)
- `trending/cache.rs` — `CachedTrending` gains `full_counts`
- `commands/trending.rs` — `ensure_all_windows_cached` stores it; `build_velocity_map` joins over the full maps

Result: rising packages (nbytes, simdutf, opencode, llhttp, …) keep their true velocity and surface, matching native.

## 3. Refresh feedback
Trending Refresh button now passes `loading={trending.loading}` to `Button` (spins + disables while refetching) instead of giving no visual feedback.

## Checks
- `cargo test trending` → 58 passed
- `svelte-check` clean

Mirrors native commit `efd45d1` (+ the velocity fix, which goes beyond it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)