### PR TITLE
Intel (x86_64) builds, missing-Homebrew onboarding, Linux support

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,118 @@
+# Linux build — the canonical recipe for producing brew-browser's
+# .deb / .rpm / .AppImage bundles.
+#
+# Tauri 2 builds all three Linux bundle targets natively via
+# `cargo tauri build` (driven here through `npm run tauri build`, which
+# also runs the SvelteKit frontend build first via beforeBuildCommand).
+#
+# Why this exists separately from the macOS flow:
+#   - macOS releases are built+signed+notarized locally on an Apple
+#     machine via tools/build/sign-and-notarize.sh (Developer ID +
+#     Apple notary — both macOS-only). That path is untouched.
+#   - Linux has no equivalent code-signing requirement for v0:
+#       * AppImage ships unsigned (the common convention).
+#       * .deb / .rpm GPG signing is a future optional step — NOT
+#         implemented here. When we add it, it slots in after the build
+#         step (sign the produced .deb/.rpm with a repo GPG key, then
+#         publish to an apt/yum repo). Left out deliberately for v0.
+#
+# What this produces: build artifacts (.deb, .rpm, .AppImage) uploaded
+# to the workflow run. Cutting an actual GitHub Release + the in-app
+# updater manifest (dist/updater.json via tools/release/publish-manifest.sh)
+# remain deliberate human steps for now.
+
+name: Linux Build
+
+on:
+  push:
+    # feat/linux-support: prove the recipe works during development.
+    # Tags v*: every tagged release builds Linux artifacts too.
+    branches:
+      - feat/linux-support
+    tags:
+      - "v*"
+  # Manual trigger from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Linux bundles (.deb / .rpm / .AppImage)
+    # Pin to ubuntu-22.04, NOT ubuntu-latest. 22.04 (Jammy) is the
+    # webkit2gtk-4.1 era and gives us the oldest glibc we commit to
+    # supporting — binaries built here run on 22.04+ and newer distros.
+    # ubuntu-latest drifts forward and would silently raise our glibc
+    # floor, breaking older targets.
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Standard Tauri 2 Linux build dependencies. Sourced from
+      # https://v2.tauri.app/start/prerequisites/ (the -dev packages are
+      # the build-time headers), plus:
+      #   - libgtk-3-dev:  GTK3 dev headers (Tauri's Linux webview shell)
+      #   - patchelf:      required by the AppImage bundler to rewrite
+      #                    rpaths in the packaged binary
+      #   - file, wget:    used by the AppImage tooling at bundle time
+      # libwebkit2gtk-4.1-dev is the 4.1 ABI Tauri 2 targets (22.04+).
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            build-essential \
+            file \
+            wget
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # Cache the cargo registry + the src-tauri/target dir keyed on the
+      # Linux target, so incremental CI runs skip recompiling unchanged
+      # crates. workspaces points at the crate root that holds Cargo.lock.
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      # Builds the frontend (beforeBuildCommand: npm run build), compiles
+      # the Rust binary, and bundles .deb / .rpm / .AppImage. bundle.targets
+      # is "all" in tauri.conf.json, which on Linux means these three.
+      - name: Build Tauri app
+        run: npm run tauri build
+
+      - name: Upload .deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: brew-browser-deb
+          path: src-tauri/target/release/bundle/deb/*.deb
+          if-no-files-found: error
+
+      - name: Upload .rpm
+        uses: actions/upload-artifact@v4
+        with:
+          name: brew-browser-rpm
+          path: src-tauri/target/release/bundle/rpm/*.rpm
+          if-no-files-found: error
+
+      - name: Upload .AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: brew-browser-appimage
+          path: src-tauri/target/release/bundle/appimage/*.AppImage
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,11 @@ __pycache__/
 
 # Icon previews — regenerable from docs/icon/brew-browser.svg via qlmanage
 docs/icon/preview-*.png
+
+# Build artifacts (never commit binaries)
+*.AppImage
+*.deb
+*.rpm
+*.dmg
+*.app.tar.gz
+*.app.tar.gz.sig

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Homebrew is the standard package manager on macOS. brew-browser gives it a real 
 
 ## Features
 
-- **Dashboard** — your Homebrew setup at a glance: installed count, updates available, brew version, formula/cask split, top-categories donut chart, storage usage (Cellar / Caskroom / var/log / cache) with one-click "Reveal in Finder", and an opt-in **Exposure** card surfacing known vulnerabilities across your install
+- **Dashboard** — your Homebrew setup at a glance: installed count, updates available, brew version, formula/cask split, top-categories donut chart, storage usage (Cellar / Caskroom / var/log / cache) with one-click "Reveal in Finder" (macOS) / "Show in file manager" (Linux), and an opt-in **Exposure** card surfacing known vulnerabilities across your install
 - **Library** — every installed formula and cask in one dense, filterable list, with outdated badges, sortable columns, category chip filters, an opt-in **Vulnerable** filter pill, inline severity dots, and a slide-over detail panel
 - **Discover** — search the full Homebrew catalog (15,974 packages, bundled at build time + user-refreshable) by name or browse via the 19-category tile grid; multi-select chip filter
 - **Trending** — top packages from Homebrew's published `formulae.brew.sh` analytics, with 30 / 90 / 365-day windows, sortable columns, a **velocity index** (recent-month vs prior-11-month adoption signal), and opt-in per-package install-trend sparklines
@@ -72,11 +72,20 @@ and parity rules: `memory-bank/decisions.md` (2026-06-01 "keep both" ADR).
 
 ## Install (end users)
 
-Both builds ship on the **[latest release](https://github.com/msitarzewski/brew-browser/releases/latest)**, signed + notarized — no Gatekeeper warning. Apple Silicon.
+Both macOS builds ship on the **[latest release](https://github.com/msitarzewski/brew-browser/releases/latest)**, signed + notarized — no Gatekeeper warning.
+
+### Which download?
+
+| Your machine | Grab |
+|----------|------|
+| Apple Silicon (M-series), macOS 13+ | `brew-browser_<version>_aarch64.dmg` |
+| Intel, macOS 13+ | `brew-browser_<version>_x64.dmg` |
+| macOS 26 (Tahoe), native build | `BrewBrowser-<version>-arm64.dmg` (M-series) or `BrewBrowser-<version>-x86_64.dmg` (Intel) |
+| Linux (Ubuntu 22.04+ era) | `.deb` / `.rpm` / `.AppImage` from the release, or the latest [Linux Build workflow run](https://github.com/msitarzewski/brew-browser/actions/workflows/linux-build.yml) |
 
 ### Tauri build — macOS 13+ (the cross-platform one)
 
-**Direct download:** grab **`brew-browser_<version>_aarch64.dmg`** from the [latest release](https://github.com/msitarzewski/brew-browser/releases/latest), open it, and drag **brew-browser** to Applications. Keeps you on the app's own verified updater (Settings → Network → Updates).
+**Direct download:** grab the `.dmg` for your Mac — **`brew-browser_<version>_aarch64.dmg`** (Apple Silicon) or **`brew-browser_<version>_x64.dmg`** (Intel) — from the [latest release](https://github.com/msitarzewski/brew-browser/releases/latest), open it, and drag **brew-browser** to Applications. Keeps you on the app's own verified updater (Settings → Network → Updates).
 
 **Homebrew:**
 
@@ -87,27 +96,42 @@ brew install --cask brew-browser
 
 Installs the same notarized `.dmg`; update later with `brew upgrade --cask brew-browser`.
 
+### Tauri build — Linux (newly supported)
+
+Linux bundles are produced by CI as `.deb`, `.rpm`, and `.AppImage`. For tagged releases, grab the `.deb` or `.AppImage` from the [releases page](https://github.com/msitarzewski/brew-browser/releases/latest); for the latest development build, download the artifacts from the most recent [Linux Build workflow run](https://github.com/msitarzewski/brew-browser/actions/workflows/linux-build.yml). Targets Ubuntu 22.04+ (the webkit2gtk-4.1 ABI) and equivalently-recent distros. Two things to know up front:
+
+- **Linux artifacts are currently unsigned.** The AppImage ships unsigned by convention; `.deb` / `.rpm` GPG signing is a documented future step. There is no Gatekeeper/notarization equivalent to satisfy, but you are running an unsigned binary — verify your download against the release checksums.
+- **GitHub sign-in needs a Secret Service daemon.** The optional GitHub integration stores its token in your system keyring via the Secret Service API (gnome-keyring, KWallet). On a desktop session this is already running; on a headless box or a minimal window manager without a Secret Service provider, GitHub sign-in fails with a "keyring unavailable" message. Everything else — browse, search, install, snapshot, services, vulnerability scanning — works regardless.
+
 ### Native build — macOS 26 (Tahoe) · Swift / SwiftUI
 
-**Direct download:** grab **`BrewBrowser-<version>.dmg`** from the [latest release](https://github.com/msitarzewski/brew-browser/releases/latest), open it, and drag **Brew Browser** to Applications. It keeps itself current via the in-app Sparkle updater. (Requires macOS 26.)
+**Direct download:** grab the `.dmg` for your Mac — **`BrewBrowser-<version>-arm64.dmg`** (Apple Silicon) or **`BrewBrowser-<version>-x86_64.dmg`** (Intel) — from the [latest release](https://github.com/msitarzewski/brew-browser/releases/latest), open it, and drag **Brew Browser** to Applications. It keeps itself current via the in-app Sparkle updater. (Requires macOS 26.)
 
 ## Build from source
 
-Prereqs:
+Prereqs (all platforms):
 
 - [Rust](https://rustup.rs/) (stable, edition 2021+)
 - [Node.js 22+](https://nodejs.org/) and npm
 - [Homebrew](https://brew.sh/) itself
-- Xcode Command Line Tools: `xcode-select --install`
 
-Then:
+Platform build prereqs:
+
+- **macOS** — Xcode Command Line Tools: `xcode-select --install`
+- **Linux** — the Tauri 2 GTK/WebKit build dependencies (`libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `patchelf`, plus `build-essential`). The canonical, always-current apt recipe lives in the CI workflow at [`.github/workflows/linux-build.yml`](./.github/workflows/linux-build.yml) — copy the `apt-get install` block from there rather than maintaining a second list here.
+
+Then (same command on every platform):
 
 ```sh
 git clone https://github.com/msitarzewski/brew-browser
 cd brew-browser
 npm install
 npm run tauri dev      # development with HMR
-npm run tauri build    # produces a .dmg in src-tauri/target/release/bundle/
+npm run tauri build    # macOS: .dmg · Linux: .deb / .rpm / .AppImage, all under src-tauri/target/release/bundle/
+
+# Intel .dmg (artifacts named _x64, under src-tauri/target/x86_64-apple-darwin/release/bundle/):
+rustup target add x86_64-apple-darwin   # one-time
+npm run tauri build -- --target x86_64-apple-darwin
 ```
 
 ### Native build (macOS 26)
@@ -126,7 +150,7 @@ swift test                  # unit tests
 
 ## Architecture
 
-**Tauri build:** a Tauri 2 shell hosts a SvelteKit + Svelte 5 frontend in the system WebView. A Rust backend exposes ~55 typed Tauri commands that shell out to `brew` via `tokio::process` and stream stdout/stderr back over typed IPC channels. The full Homebrew catalog is bundled at build time (~6 MiB gzipped) and refreshable on demand. Trending data comes straight from `formulae.brew.sh`'s public analytics JSON, cached in memory for an hour. Optional GitHub integration uses OAuth Device Flow with the token stored only in the macOS Keychain. No shell plugin, no arbitrary command execution — every `brew` invocation is built in Rust from a small set of enumerated inputs. See [docs/PLAN.md](./docs/PLAN.md) for the full design and [memory-bank/backendApi.md](./memory-bank/backendApi.md) for the complete IPC surface.
+**Tauri build:** a Tauri 2 shell hosts a SvelteKit + Svelte 5 frontend in the system WebView. macOS is the primary target; Linux is newly supported (same codebase, built on Ubuntu 22.04+ via CI). A Rust backend exposes ~55 typed Tauri commands that shell out to `brew` via `tokio::process` and stream stdout/stderr back over typed IPC channels. Paths are derived from `brew --prefix` / `brew --cache` rather than hardcoded, so the Linuxbrew prefix (`/home/linuxbrew/.linuxbrew`, or `~/.linuxbrew`) is picked up automatically alongside the macOS `/opt/homebrew`. The full Homebrew catalog is bundled at build time (~6 MiB gzipped) and refreshable on demand. Trending data comes straight from `formulae.brew.sh`'s public analytics JSON, cached in memory for an hour. Optional GitHub integration uses OAuth Device Flow with the token stored only in the system keyring (macOS Keychain; Secret Service / gnome-keyring / KWallet on Linux). No shell plugin, no arbitrary command execution — every `brew` invocation is built in Rust from a small set of enumerated inputs. See [docs/PLAN.md](./docs/PLAN.md) for the full design and [memory-bank/backendApi.md](./memory-bank/backendApi.md) for the complete IPC surface.
 
 **Native build:** a Swift 6 + SwiftUI app (`native/`, a Swift Package — no `.xcodeproj`). Stock Apple scaffolding only — `NavigationSplitView`, `.inspector`, `Settings`/`SettingsLink`, `Form`, Liquid Glass materials — no custom window chrome. Stateless services (`BrewService`, `GitHubService`, `VulnsService`) are `Sendable struct`s that mirror the Rust modules and shell out to `brew` via `Foundation.Process` with typed argument arrays (no shell). The same bundled JSON data contract; settings persist to the same `settings.json` schema; updates via Sparkle 2. See `native/README.md`.
 
@@ -140,11 +164,11 @@ brew-browser makes outbound network calls in exactly twelve documented circumsta
 - **`https://formulae.brew.sh/api/{formula,cask}.json`** — the full Homebrew catalog. Bundled at build time so the app works offline. A user-initiated **Refresh** button on the Dashboard (or the Discover stale-catalog banner) writes a fresh copy to `~/Library/Application Support/brew-browser/catalog/`. Auto-refresh is **off** by default; Settings → Network offers weekly / daily opt-in.
 - **Cask homepage probes** — when the Discover or Trending tab renders an uninstalled cask that has a `homepage` field, the Rust backend probes that homepage for an icon (in order: `/apple-touch-icon.png`, `<meta og:image>` parsed from the homepage HTML, `/favicon.ico`). One probe per cask per week max — the result, including misses, is cached for 7 days. These probes are sandboxed: link-local, loopback, RFC1918, and cloud-metadata IPs are rejected before the request, and the same check runs again on every redirect hop to prevent SSRF. Settings → Network can scope this to **installed only** or disable it entirely.
 - **`https://api.github.com/repos/{owner}/{repo}`** (read) — optional, **off by default**. When **Settings → GitHub → "Show GitHub stats on package pages"** is on, the PackageDetail panel fetches public repo metadata (stars, forks, last release date, archived state) for packages whose homepage (or `urls.stable.url` / `urls.head.url` / cask `url`) parses as a GitHub URL. The URL parser strictly allowlists `github.com` (rejects `gist.`, `raw.githubusercontent.`, suffix-attack domains, path traversal). Results cached to `~/Library/Application Support/brew-browser/github-cache/` for 24 hours. Anonymous rate limit is 60 reqs/hr per IP; sign-in lifts it to 5,000/hr.
-- **`https://github.com/login/{device,oauth}/*`** — optional, only when you click **Sign in with GitHub** in Settings (or hit the inline Re-authorize button on a scope-required toast). Uses OAuth Device Flow (RFC 8628): you see a user code, open `github.com/login/device` in your browser, paste it, done. No embedded webview, no client secret, no callback URL. Scopes requested: `read:user` + `public_repo` + `notifications` (the minimum for username + star + file-issue + watch). Access token stored exclusively in **macOS Keychain** under `com.zerologic.brew-browser/github_access_token`. **The token is never returned to the frontend, never written to disk, and never logged** — verified by unit tests.
+- **`https://github.com/login/{device,oauth}/*`** — optional, only when you click **Sign in with GitHub** in Settings (or hit the inline Re-authorize button on a scope-required toast). Uses OAuth Device Flow (RFC 8628): you see a user code, open `github.com/login/device` in your browser, paste it, done. No embedded webview, no client secret, no callback URL. Scopes requested: `read:user` + `public_repo` + `notifications` (the minimum for username + star + file-issue + watch). Access token stored exclusively in the OS credential store under `com.zerologic.brew-browser/github_access_token` — the **macOS Keychain** on macOS, the **Secret Service** (gnome-keyring / KWallet, persistent across reboot) on Linux. On a Linux session with no Secret Service daemon, sign-in fails with a "keyring unavailable" message and the rest of the app is unaffected. **The token is never returned to the frontend, never written to disk by us, and never logged** — verified by unit tests.
 - **`https://api.github.com/{user/starred,repos/.../subscription,repos/.../issues}`** (write) — optional, only when you click Star, Watch, or File-issue on a package detail page after signing in. Each action is gated server-side by a per-action OAuth scope check (`public_repo` for star + file-issue; `notifications` for watch/unwatch) so a token missing the right scope fails fast with a typed `scope_required` error before any GitHub round-trip.
 - **`brew` itself** — every install, uninstall, upgrade, search, and snapshot shells out to the real `brew` CLI. Whatever network calls `brew` makes (GitHub, OCI registries, bottle mirrors) happen exactly as they would if you ran the command yourself in a terminal. The full stdout/stderr stream is visible in the Activity drawer.
 - **Your default browser** — when you click the homepage button on a package, the URL is opened in your default browser via macOS `open(1)`. The app rejects any non-`http(s)` scheme before opening.
-- **`https://brew-browser.zerologic.com/updater.json`** + **`https://github.com/msitarzewski/brew-browser/releases/download/v*/brew-browser_*_aarch64.app.tar.gz`** — the in-app updater (Phase 15, v0.3.0+). The manifest fetch happens when you click **Check for updates now** in Settings → Network → Updates, or on the auto-check timer if you opt in (off by default; 24h cadence). The artifact download follows only after the manifest's `version` is strictly greater than the running build. Every downloaded `.app.tar.gz` is verified against an embedded minisign public key + the manifest's `sha256` before any on-disk side effect — mismatch aborts with no install. Skipping a version is recorded locally; a future release re-triggers the indicator.
+- **`https://brew-browser.zerologic.com/updater.json`** + **`https://github.com/msitarzewski/brew-browser/releases/download/v*/brew-browser_*_{aarch64,x64}.app.tar.gz`** — the in-app updater (Phase 15, v0.3.0+). The manifest fetch happens when you click **Check for updates now** in Settings → Network → Updates, or on the auto-check timer if you opt in (off by default; 24h cadence). The artifact download follows only after the manifest's `version` is strictly greater than the running build. Every downloaded `.app.tar.gz` is verified against an embedded minisign public key + the manifest's `sha256` before any on-disk side effect — mismatch aborts with no install. Skipping a version is recorded locally; a future release re-triggers the indicator.
 - **`https://brew-browser.zerologic.com/trending-history/*`** — Enhanced Trending History (v0.4.0+). **Distinct trust boundary** from the Homebrew first-party endpoints above: this endpoint is operated by the brew-browser project, not by upstream Homebrew. **Off by default.** When you opt in via Settings → Network → Enhanced Trending History, the app fetches per-package historical install trends to power inline sparklines on the Trending tab and a chart on each package's detail panel. Only the package name you're viewing is sent (one HTTP GET per package); no IP is logged at the server, no cookies, no fingerprinting (see `memory-bank/security.md` §16 for the Caddy config that makes the privacy claim auditable). Master Offline Mode hard-locks this off regardless of the per-feature toggle.
 - **`https://brew-browser.zerologic.com/enrichment/*`** — Live category & description updates. **Same first-party host as Enhanced Trending, distinct `/enrichment/*` path** — still a separate trust boundary from the always-on Homebrew endpoints. **Off by default.** brew-browser ships with bundled AI categories + descriptions; when you opt in via Settings → Network → Live category & description updates, it refreshes them: a tiny `version.json` probe on catalog refresh, the full `categories.json` when its version is newer, and a per-package `entry/<token>.json` when you open that package's detail. Only the package name you're viewing is sent (one HTTP GET per token); no IP logged, no cookies. Requires AI Features on; master Offline Mode hard-locks it off regardless.
 - **`https://api.osv.dev`** + **`https://github.com` / `https://gitlab.com` / `https://codeberg.org`** (via subprocess) + **`https://api.github.com/advisories/{GHSA_ID}`** (from our code) — opt-in **Vulnerability Scanning** (v0.5.0+). **Distinct trust boundary** because the OSV traffic and the source-forge tag resolution are opened by the `brew vulns` subprocess we shell out to, not by brew-browser's own binary. **Off by default.** When you opt in via Settings → Network → Vulnerability Scanning (and install `brew vulns` via the one-click affordance if you don't already have it), the app runs `brew vulns --json` to query OSV.dev for known CVEs against your installed formulae. When **both** the vulnerability-scanning toggle AND GitHub sign-in are on, each `GHSA-…`-prefixed finding is enriched via `api.github.com/advisories/{GHSA_ID}` from our Rust code (triple-defense: master Offline Mode, vuln-feature toggle, GitHub-feature toggle — all three must align for one GHSA request). `brew vulns` is published by Homebrew (`Homebrew/homebrew-brew-vulns`, by Andrew Nesbitt). Casks are not supported (`brew vulns` is formula-only); cask UI rows render an honest "Cask coverage isn't supported" message rather than fake clean state. Master Offline Mode hard-locks the whole feature off regardless. See `memory-bank/security.md` §17 for the endpoint audit and gate-composition table.
@@ -234,7 +258,7 @@ Contributions welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the dev loop
 
 ## Built with
 
-Built with **[Agency Agents](https://github.com/msitarzewski/agency-agents)**, by the creator of Agency Agents — the multi-agent toolkit (Backend Architect, Frontend Developer, Security Engineer, Code Reviewer, Technical Writer, and friends) that orchestrated brew-browser's design and implementation. Powered by Claude Code in the terminal, running Opus 4.7 [1m].
+Built with **[Agency Agents](https://github.com/msitarzewski/agency-agents)**, by the creator of Agency Agents — the multi-agent toolkit (Backend Architect, Frontend Developer, Security Engineer, Code Reviewer, Technical Writer, and friends) that orchestrated brew-browser's design and implementation. Powered by Claude Code in the terminal, running Opus 4.8 (1M context).
 
 ## Support the project
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -93,7 +93,7 @@
         <a class="btn btn-primary" href="https://github.com/msitarzewski/brew-browser/releases/latest">Download</a>
         <a class="btn btn-secondary" href="https://github.com/msitarzewski/brew-browser">Source on GitHub</a>
       </div>
-      <p class="small-note">Tauri: macOS 13+ &amp; Linux · Native: Swift/SwiftUI, macOS 26 · Apple Silicon · MIT · no telemetry, no accounts</p>
+      <p class="small-note">Tauri: macOS 13+ &amp; Linux · Native: Swift/SwiftUI, macOS 26 · Apple Silicon &amp; Intel · MIT · no telemetry, no accounts</p>
     </div>
   </header>
 
@@ -204,6 +204,13 @@
     <section class="section section-bordered">
       <h2>Get it</h2>
       <p><strong>Direct download (recommended):</strong> the signed &amp; notarized <code>.dmg</code> is on the <a href="https://github.com/msitarzewski/brew-browser/releases/latest">latest release</a>. It's the build signed and tested directly each release, and it keeps you on the app's own verified updater.</p>
+      <p><strong>Which download?</strong></p>
+      <ul class="posture">
+        <li><strong>Apple Silicon (M-series), macOS 13+.</strong> <code>brew-browser_&lt;version&gt;_aarch64.dmg</code></li>
+        <li><strong>Intel Mac, macOS 13+.</strong> <code>brew-browser_&lt;version&gt;_x64.dmg</code></li>
+        <li><strong>Native build, macOS 26.</strong> <code>BrewBrowser-&lt;version&gt;-arm64.dmg</code> (M-series) or <code>BrewBrowser-&lt;version&gt;-x86_64.dmg</code> (Intel).</li>
+        <li><strong>Linux.</strong> Coming.</li>
+      </ul>
       <p>Or install with Homebrew:</p>
       <pre><code>brew tap msitarzewski/brew-browser
 brew install --cask brew-browser</code></pre>

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,42 @@
 # Active Context
 
+> ## 🔧 IN FLIGHT 2026-06-10/11: `feat/intel-builds-and-onboarding` (committed + pushed, PR pending)
+>
+> Triggered by post-release "corrupt download" reports → root cause was Intel
+> users opening arm64-only dmgs (artifacts audited bit-perfect; nothing corrupt).
+> Three workstreams, all BUILT + QA GREEN + VM-VERIFIED — full record:
+> `tasks/2026-06/13-intel-builds-onboarding-linux.md`:
+>
+> - **WS1 Onboarding (both shells):** brew-missing → guided first-run view
+>   (CLT step on macOS, apt-deps note on Linux, Copy primary, Open Terminal
+>   macOS-only, fixed-constant command strings) + 2s poll → auto-dissolve into
+>   the library, same process, no relaunch. **Proven live on the Linux VM**
+>   (real nuke → onboarding → real reinstall → auto-recovery).
+> - **WS2 Intel:** Tauri x86_64 (separate dmgs, NOT universal — user decision;
+>   `darwin-x86_64` manifest key; per-arch cask at release time) + native
+>   per-arch zips/dmgs (`release.sh` loops arches; appcast-ordering bug fixed).
+>   x64 cross-compiles verified BOTH stacks (native x64 .app assembled end-to-
+>   end). ⚠️ **Tauri release builds on this host: E0463 proc-macro failures
+>   ROOT-CAUSED** — `tauri build` exports `MACOSX_DEPLOYMENT_TARGET=13.0` and
+>   the macOS 27 beta toolchain makes proc-macro dylibs built under that env
+>   unloadable; cargo doesn't fingerprint the var so the taint persists until
+>   `cargo clean`. Recipe: rustup toolchain on PATH + PRIME with plain
+>   `cargo build --release [--target …]` before each `npm run tauri build`.
+>   Full forensics + recipe: task doc 13 caveats.
+> - **WS3 Linux:** `282d8ff` integrated (3-way, conflicts resolved), deb/rpm/
+>   AppImage build + install + run **verified in the Scratch VM** (GNOME
+>   Wayland, Linuxbrew detect, real installs). **Casks fully gated on Linux**
+>   (data layer: catalog/search; UI sweep: Dashboard/Library/Trending/Discover/
+>   Settings/Snapshots/About — casks are a macOS-only concept, no Linux variant).
+>
+> **QA:** cargo 618 ✅ | svelte-check 0 err ✅ | swift 44 ✅ | dead-code warnings
+> cleaned (vulns/cache.rs `#[allow]` per file precedent). **Next:** PR → release
+> (proposed Tauri 0.5.2 + native 0.1.1, user to confirm), per-arch cask body in
+> ws2-tauri agent report, Linux artifacts ship "manual install, no auto-update"
+> first round (updater story unwired). VM left brew 6.0.0 + jq/tree/alluxio.
+>
+> ---
+>
 > ## 🚀 SHIPPED 2026-06-07: Tauri 0.5.1 + native 0.1.0 (first native release)
 >
 > Both builds signed, notarized, released (tag `v0.5.1` on `main`); Tauri updater

--- a/memory-bank/decisions.md
+++ b/memory-bank/decisions.md
@@ -526,3 +526,31 @@ defined roles). See [[project-native-swift-rebuild]] cross-session memory.
   snapshot path stays; a hybrid (prefer brew's cache, fall back to bundled) is a
   deferred roadmap item. Interim: regenerate the bundle each release via
   `tools/catalog/fetch.py` (done 2026-06-07: as_of now, 8404 formulae / 7703 casks).
+
+## 2026-06-11: Intel = separate per-arch builds (not universal); casks gated off Linux; installer never runs in-app
+
+- **Separate arm64 + x86_64 artifacts for BOTH builds, no universal binaries**
+  (user decision: "universal adds unnecessary weight for arm users"). Tauri:
+  two dmgs, updater manifest gains `darwin-x86_64`, cask goes per-arch
+  (`sha256 arm:/intel:`). Native: `build-app.sh [config] [arch]` +
+  `release.sh` loops arches into arch-suffixed zips/dmgs; single Sparkle feed
+  first (generate_appcast emits `sparkle:hardwareRequirements`), dual-feed
+  fallback documented in the script if it can't disambiguate. Native x86_64
+  audience = the four Intel Macs that run macOS 26 (MBP 16" 2019, MBP 13"
+  2020 4-port, iMac 27" 2020, Mac Pro 2019 — Apple 122867); Intel Mac minis
+  cap at Sequoia → served by the Tauri x64 dmg (min macOS 13).
+- **Casks are a macOS-only concept — gate them out of Linux entirely**, data
+  layer first (`catalog_casks_summary` empty, `brew search --cask` never
+  spawned) plus a UI terminology sweep behind `isLinux`. Homebrew has no
+  Linux cask mechanism even for apps with native Linux builds (Flatpak/Snap
+  own that role). Hiding beats erroring: "macOS is required" mid-install is
+  a trust-destroying dead end. The Library/PackageRow kind cell survives as a
+  12px slot because it also hosts the vulnerability dot (functional on Linux).
+- **The Homebrew installer never runs inside the app** (onboarding): it needs
+  sudo + an interactive TTY, and an app silently wielding admin rights is the
+  exact trust failure brew-browser avoids. Open Terminal pre-types a FIXED
+  constant command (macOS); Linux is copy-only. The app polls the known
+  prefixes every 2s and recovers in-process — PATH setup isn't needed for
+  detection because we watch prefixes directly, not the shell environment.
+
+**References**: `tasks/2026-06/13-intel-builds-onboarding-linux.md`

--- a/memory-bank/tasks/2026-06/13-intel-builds-onboarding-linux.md
+++ b/memory-bank/tasks/2026-06/13-intel-builds-onboarding-linux.md
@@ -1,0 +1,176 @@
+# 13 — Intel builds + missing-Homebrew onboarding + Linux integration (both builds)
+
+**Date:** 2026-06-10/11 | **Branch:** `feat/intel-builds-and-onboarding` (off `main` @ v0.5.1) | **Status:** built + QA green, uncommitted, awaiting commit/PR/release
+
+## Objective
+
+Triggered by post-0.5.1 "corrupt download" reports that turned out to be Intel
+Mac users opening arm64-only dmgs (audit record: every shipped 0.1.0/0.5.1
+artifact verified bit-perfect, signed, notarized, stapled — nothing was
+actually corrupt). Three approved workstreams, built via multi-agent workflow
+(4 parallel build agents → Linux integration agent → QA loop, green in 1 cycle):
+
+1. **WS1 — Missing-Homebrew onboarding** (both shells): replace the dead-end
+   "Homebrew was not found" error with a guided first-run experience.
+2. **WS2 — Intel (x86_64) builds**: Tauri per-arch dmgs + native per-arch
+   artifacts (user decision: separate builds, NOT universal — no extra weight
+   for arm64 users).
+3. **WS3 — Linux**: bring `282d8ff` (feat/linux-support, was 99 behind) onto
+   the branch and integrate with the new onboarding.
+
+## Outcome
+
+- ✅ cargo: **618 passed**, 0 failed (585 → 618)
+- ✅ svelte-check: 0 errors, 3 warnings (exact pre-existing baseline)
+- ✅ swift: **44 passed** (36 → 44, 8 new onboarding/VulnsService tests)
+- ✅ `bash -n` clean: all 4 release-tooling scripts
+- ✅ x86_64 `swift build` cross-compile verified on the dev host
+- ✅ Tauri x86_64-apple-darwin `cargo check` verified (with the RUSTC pin below)
+- ✅ **Linux verified end-to-end in the Scratch VM (2026-06-11):** all 3 bundles
+  built (deb/rpm/AppImage, arm64); deb installed; app launched in a real GNOME
+  Wayland session; Dashboard loaded 3 Linuxbrew formulae with storage paths
+  resolved to `/home/linuxbrew/.linuxbrew`. **Onboarding verified live:** hid
+  the Linuxbrew prefix → relaunch showed the onboarding view (Linux copy with
+  apt build-deps step, Copy primary, Open Terminal correctly absent) → restored
+  the prefix while the app ran → the 2s poll detected it and the SAME process
+  dissolved into the loaded Dashboard, no relaunch. Screenshots captured via
+  `prlctl capture` (gnome-screenshot is blocked under Wayland).
+- Diff: 32 files changed, +1,757 / −272, +3 new files
+
+## Files Modified (key)
+
+### WS1 Tauri
+- `src-tauri/src/commands/env.rs` — extended the existing brew_doctor probe
+  module (reuse over creation): `SystemStatus` DTO, `system_status()`,
+  `brew_redetect()`, `open_terminal_install()` with the Homebrew install
+  one-liner as a **fixed raw-string constant** (zero interpolation; osascript
+  `do script` + `activate`; spawn failure → typed error → frontend copy fallback)
+- `src-tauri/src/state.rs:279-298` — `set_brew_path()` + `redetect_brew_path()`
+  (re-runs `resolve_brew_path()`, writes the `RwLock` — recovery without relaunch)
+- `src-tauri/src/lib.rs` — 3 commands registered
+- `src/lib/components/OnboardingView.svelte` (new) — gates `+page.svelte`;
+  CLT step → install one-liner + Copy + Open Terminal (copy is primary);
+  2s poll via `brew_redetect`; auto-dissolves into `packages.load(true)`
+- `src/lib/types.ts`, `src/lib/api.ts`, `src/lib/stores/env.svelte.ts` — bindings/gate
+
+### WS1 native
+- `BrewService.swift:113` — `resolveBrewPath()` promoted to internal shared resolver
+- `VulnsService.swift` — **bug fix**: hardcoded `/opt/homebrew/bin/brew` fallback
+  removed; `brewPath: String?`, nil → throws `.brewNotFound` (no fake paths)
+- `AppModel.swift:893-961` — `brewMissing`/`cltInstalled` state set synchronously
+  in `init` (no flash of normal UI); `pollForBrew()` 2s loop, off-main probes;
+  `commandLineToolsInstalled()` via `xcode-select -p`
+- `OnboardingView.swift` (new) — stock SwiftUI only; `ContentView.swift` gate
+- `OnboardingStateTests.swift` (new) + VulnsService test updates
+
+### WS2 (release tooling)
+- `tools/build/sign-and-notarize.sh` — per-arch dmg discovery (aarch64 mandatory,
+  x64 skip-if-absent with warning); notarize/staple/verify loop over both
+- `tools/release/publish-manifest.sh` — `darwin-x86_64` platform key
+  (`brew-browser_<v>_x64.app.tar.gz`), gated: absent → loud warn + omit;
+  present-without-sig → exit 2
+- `native/build-app.sh` — `[debug|release] [arm64|x86_64]`; `--arch` flag with
+  `--show-bin-path` bindir resolution (handles both SwiftPM layout generations);
+  no-arg behavior byte-identical; re-sign-inside-out-last preserved
+- `native/release.sh` — per-arch loop → `BrewBrowser-<v>-<arch>.{zip,dmg}`;
+  **`generate_appcast` now runs over a zips-only dir BEFORE dmgs are built**
+  (fixes the latent bug where dist dmgs would pollute the next appcast scan);
+  single feed relying on `sparkle:hardwareRequirements`, dual-feed fallback
+  documented in the post-run checklist
+- `README.md` + `landing/index.html` — "Which download?" guide per arch/build
+
+### WS3 Linux (from `282d8ff`, 3-way applied, conflicts resolved)
+- Per-target keyring features (`Cargo.toml`: macOS apple-native +
+  security-framework; Linux sync-secret-service + crypto-rust)
+- Linuxbrew prefixes in `brew/paths.rs`; exec cwd pinned to `/`
+- cfg-gated Finder reveal / cask icons / native menu (`lib.rs`)
+- New: `tauri.linux.conf.json`, `.github/workflows/linux-build.yml`,
+  `src/lib/util/platform.ts`
+- Onboarding Linux-aware: Open Terminal gated off (frontend + backend), Linuxbrew copy
+
+## Addendum (2026-06-11): casks don't exist on Linux — data + UI gating
+
+User testing on the VM surfaced casks being offered on Linux (Install could only
+fail with "macOS is required"). Casks are a macOS-only Homebrew concept (no
+Linux variant exists, even for apps with native Linux builds — Flatpak/Snap own
+that role there). Fixes, all verified on the VM:
+
+**Data layer:** `catalog.rs` `catalog_casks_summary` returns empty on
+non-macOS (kills Discover tiles/search/category counts at the source);
+`search.rs` never spawns `brew search --cask` on non-macOS;
+`PackageDetail.svelte` `caskOnLinux` guard replaces Install with "Casks require
+macOS" for any cask that still surfaces (snapshots/deep links).
+
+**UI terminology sweep (gated on `isLinux` from `src/lib/util/platform.ts`;
+macOS rendering byte-identical):** Dashboard Composition card hidden +
+Caskroom storage row dropped; Library "Casks" filter chip removed + Type column
+hidden (the kind cell stays as a 12px slot — it also hosts the vulnerability
+severity dot, which IS functional on Linux); Trending Type column removed
+(responsive grid reworked); Discover category browse skips cask tokens from the
+platform-agnostic bundled categories.json (counts agree); Settings network copy
+reworded (no cask icon control/probe entries, `xdg-open` instead of "macOS
+open(1)" — verified against the opener plugin's actual Linux behavior);
+Snapshots keeps real cask counts from Mac-origin snapshots but drops "0 casks"
+noise, and its empty-state shows the XDG path (`~/.local/share/...`) and
+"another machine" on Linux; About credits formula-only.
+
+QA after sweep: cargo test green, svelte-check 0 errors / 3 baseline warnings.
+VM-verified screenshots: Dashboard, Library, Trending, Discover all cask-free.
+
+## Decisions
+
+- **Separate arch builds, not universal** (user): arm64 users don't pay Intel
+  weight. Native: single Sparkle feed first (generate_appcast emits
+  `hardwareRequirements`), dual-feed fallback documented.
+- **Native x86_64 audience**: the four Intel Macs on macOS 26 (MBP 16" 2019,
+  MBP 13" 2020 4-port, iMac 27" 2020, Mac Pro 2019) — confirmed via Apple
+  support page 122867. Intel Mac minis cannot run Tahoe → served by Tauri x64.
+- **Installer never runs in-app**: needs sudo + TTY; Open Terminal pre-types
+  the fixed command, Copy is primary (osascript Automation prompt is one-time).
+- **Reuse**: commands went into existing `env.rs` (the env/probe cluster);
+  no new Rust module created.
+
+## Known caveats
+
+- Dev-host `swift test` requires `DEVELOPER_DIR=/Applications/Xcode-beta.app/...`
+  (CLT toolchain has a broken swift-package dyld link) + a gitignored
+  `.build/` symlink for the Sparkle test bundle. Environment-only.
+- Cask per-arch body (on_arm/on_intel) prepared in the build report — applied
+  in the tap repo at release time.
+- Tauri x64 release requires `rustup target add x86_64-apple-darwin` (done on
+  dev host 2026-06-11).
+- **Dev-host Tauri release-build gotcha — ROOT-CAUSED 2026-06-11 (E0463
+  proc-macro failures):** `tauri build` exports
+  `MACOSX_DEPLOYMENT_TARGET=13.0` (from `tauri.conf.json`
+  `minimumSystemVersion`). On this host's macOS 27 beta toolchain, proc-macro
+  dylibs *built under that env* are unloadable by rustc → `E0463 can't find
+  crate` for `ctor_proc_macro`/`phf_macros`/`thiserror_impl`/… (dylib is
+  correct-arch, correct-version, signed, passed via `--extern`; rustc just
+  can't load it — suspected beta dyld/ld regression, recheck after Xcode
+  updates). Reproduced minimally: `MACOSX_DEPLOYMENT_TARGET=13.0 cargo build
+  --release` on a fresh crate with `ctor` fails identically; without the env
+  it passes. **Amplifier:** cargo does NOT fingerprint that env var, so
+  tainted proc-macros are silently reused by every subsequent build (either
+  toolchain, both arches) — failures persist until `cargo clean`. This also
+  produced red herrings all evening (mixed Homebrew-1.95/rustup-1.96 runs).
+  **Working recipe (PROVEN 2026-06-11: produced both dmgs incl. the first
+  `_x64.dmg`). Order matters — prime BOTH arches BEFORE any tauri build, and
+  feature-match the prime or `tauri_macros` rebuilds tainted:**
+  1. one toolchain only — rustup's, which has the x64 std:
+     `export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`
+  2. if the target dir ever saw a tauri build that failed E0463: `cargo clean`
+     (a failed tauri build taints the cache for ALL later builds, primes
+     included)
+  3. PRIME env-free, feature-matched, both arches first:
+     `cargo build --release --features tauri/custom-protocol`
+     `cargo build --release --features tauri/custom-protocol --target x86_64-apple-darwin`
+  4. only then bundle: `npm run tauri build` and
+     `npm run tauri build -- --target x86_64-apple-darwin`
+  (Priming is build-time only — shipped binaries still link with deployment
+  target 13.0 as configured. Proc-macros never ship.)
+- Plain `cargo test` (dev profile, no tauri env) is unaffected: 618 green.
+
+## Artifacts
+
+- Workflow run `wf_a5f4aa56-486` (6 agents, QA green cycle 1/3)
+- PR: pending (branch uncommitted at time of writing)

--- a/memory-bank/tasks/2026-06/README.md
+++ b/memory-bank/tasks/2026-06/README.md
@@ -29,6 +29,7 @@ Native macOS build under `native/`.
 |---|---|---|---|
 | 11 | [Launch batch: upgrade-all fix + #58 + #57, native test target, security pass](./11-launch-batch-progress-category-upgrade.md) | 2026-06-07 | `feat/launch-batch-progress-category-upgrade` |
 | 12 | [Release: Tauri 0.5.1 + native 0.1.0 (first native release) — SHIPPED](./12-release-v0.5.1-native-0.1.0.md) | 2026-06-07 | `v0.5.1` tag / `main` |
+| 13 | [Intel (x86_64) builds + missing-Homebrew onboarding + Linux integration](./13-intel-builds-onboarding-linux.md) | 2026-06-10/11 | `feat/intel-builds-and-onboarding` |
 
 ## Tauri track (`main`)
 

--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -890,7 +890,74 @@ public final class AppModel {
     private let trendingService = TrendingService()
     private let githubService = GitHubService()
 
-    public init() {}
+    public init() {
+        // Launch gate: a missing brew binary routes the whole window into the
+        // onboarding pane (ContentView) instead of the normal initial loads.
+        // Synchronous + cheap (two FileManager stats), so the very first body
+        // evaluation already knows which root to build — no flash of the
+        // normal UI before the gate kicks in.
+        brewMissing = BrewService.resolveBrewPath() == nil
+    }
+
+    // MARK: - Missing-Homebrew onboarding
+
+    /// True while no brew binary resolves — ContentView swaps the whole window
+    /// for `OnboardingView` and `pollForBrew()` re-checks until one appears.
+    /// Set synchronously at init (the launch gate) and cleared by the poll.
+    var brewMissing = false
+
+    /// Whether the Xcode Command Line Tools are installed (`xcode-select -p`
+    /// exits 0). Drives the onboarding step list: the CLT step is shown first
+    /// when they're missing, since the Homebrew installer needs them. Probed
+    /// by `pollForBrew()` each pass; meaningful only while onboarding shows.
+    var cltInstalled = false
+
+    /// One onboarding poll step, split from the loop so tests can drive the
+    /// transitions without a real install: records the CLT probe, exits the
+    /// onboarding state when brew resolved. Returns true when onboarding is
+    /// over (brew found) so the caller can stop polling.
+    @discardableResult
+    func updateOnboarding(brewFound: Bool, cltFound: Bool) -> Bool {
+        cltInstalled = cltFound
+        if brewFound { brewMissing = false }
+        return !brewMissing
+    }
+
+    /// Re-check every 2s while the onboarding pane is up: does a brew binary
+    /// resolve yet, and are the CLT installed? When brew appears the flag
+    /// flips and the normal root view (whose `.task`s fire the standard
+    /// initial load sequence) replaces the onboarding pane. Runs from
+    /// OnboardingView's `.task`, so SwiftUI cancels it with the view.
+    func pollForBrew() async {
+        while brewMissing, !Task.isCancelled {
+            // Probe off the main actor — both checks shell out / stat files.
+            let (brewFound, cltFound) = await Task.detached(priority: .utility) {
+                (BrewService.resolveBrewPath() != nil, Self.commandLineToolsInstalled())
+            }.value
+            if updateOnboarding(brewFound: brewFound, cltFound: cltFound) { return }
+            try? await Task.sleep(for: .seconds(2))
+        }
+    }
+
+    /// `xcode-select -p` exit 0 = the Command Line Tools (or full Xcode) are
+    /// installed. Fixed executable + args, no interpolation; any spawn failure
+    /// reads as not-installed.
+    nonisolated static func commandLineToolsInstalled() -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcode-select")
+        process.arguments = ["-p"]
+        process.currentDirectoryURL = URL(fileURLWithPath: "/")
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
 
 #if DEBUG
     /// A model pre-populated with representative data for SwiftUI `#Preview`s

--- a/native/Sources/BrewBrowserKit/BrewService.swift
+++ b/native/Sources/BrewBrowserKit/BrewService.swift
@@ -110,7 +110,11 @@ struct BrewService: Sendable {
 
     /// Resolve the brew binary the same way the Rust backend does: prefer the
     /// Apple-Silicon prefix, fall back to the Intel path, then bare PATH lookup.
-    private static func resolveBrewPath() -> String? {
+    /// Internal (not private) — the single source of truth for "is Homebrew
+    /// installed?": `VulnsService` resolves through it, and `AppModel`'s
+    /// missing-Homebrew onboarding gate polls it. Returns nil when no install
+    /// is found; callers must surface that, never substitute a fake path.
+    static func resolveBrewPath() -> String? {
         let candidates = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
         for c in candidates where FileManager.default.isExecutableFile(atPath: c) {
             return c

--- a/native/Sources/BrewBrowserKit/ContentView.swift
+++ b/native/Sources/BrewBrowserKit/ContentView.swift
@@ -33,6 +33,20 @@ public struct ContentView: View {
     }
 
     public var body: some View {
+        // Missing-Homebrew gate: while no brew binary resolves, the whole
+        // window is the onboarding pane. The normal chrome (and its `.task`
+        // initial loads — bundled data, GitHub status, library) doesn't exist
+        // until brew appears, so nothing fires brew subprocesses early. When
+        // `pollForBrew` flips the flag, `mainContent` is built and those
+        // `.task`s run the standard initial load sequence.
+        if model.brewMissing {
+            OnboardingView(model: model)
+        } else {
+            mainContent
+        }
+    }
+
+    private var mainContent: some View {
       VStack(spacing: 0) {
         NavigationSplitView {
             List(Section.allCases, selection: $model.selection) { section in

--- a/native/Sources/BrewBrowserKit/OnboardingView.swift
+++ b/native/Sources/BrewBrowserKit/OnboardingView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+import AppKit
+
+/// Full-window onboarding pane shown when no Homebrew install can be found
+/// (`AppModel.brewMissing` — ContentView swaps the whole root for this view).
+/// Walks the user through the official install: Command Line Tools first when
+/// they're missing, then the Homebrew one-liner, with a Copy button and an
+/// "Open Terminal" shortcut. A footer spinner notes that the app re-checks on
+/// its own (`AppModel.pollForBrew`, every 2s) and proceeds automatically.
+///
+/// Stock SwiftUI only — standard text styles, `GroupBox`, `ProgressView`,
+/// plain buttons. No window/chrome/material overrides.
+struct OnboardingView: View {
+    @Bindable var model: AppModel
+
+    /// The official Homebrew install one-liner (brew.sh), surfaced VERBATIM.
+    /// A fixed constant — never built up or interpolated.
+    static let installCommand =
+        #"/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)""#
+
+    /// The Apple command that installs the Command Line Tools. Fixed constant,
+    /// shown (and copied) verbatim.
+    static let cltCommand = "xcode-select --install"
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            // Headline — mirrors the ContentUnavailableView layout the app's
+            // other full-pane states use (icon, title, secondary description),
+            // hand-rolled here because this pane also carries steps + actions.
+            VStack(spacing: 8) {
+                Image(systemName: "shippingbox")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.secondary)
+                Text("Homebrew isn't installed")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Text("brew-browser is a window onto Homebrew — install it and the app takes it from there.")
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(alignment: .leading, spacing: 16) {
+                // Step: Command Line Tools, only when the probe says missing —
+                // the Homebrew installer needs them, so they come first.
+                if !model.cltInstalled {
+                    step(number: 1, title: "Install the Xcode Command Line Tools",
+                         detail: "The Homebrew installer needs them. Run this in Terminal and follow the prompt:",
+                         command: Self.cltCommand)
+                }
+
+                step(number: model.cltInstalled ? 1 : 2, title: "Install Homebrew",
+                     detail: "Paste the official install command (from brew.sh) into Terminal:",
+                     command: Self.installCommand)
+
+                HStack {
+                    Spacer()
+                    Button {
+                        openTerminal()
+                    } label: {
+                        Label("Open Terminal", systemImage: "terminal")
+                    }
+                    Spacer()
+                }
+            }
+            .frame(maxWidth: 560)
+
+            // Quiet auto-advance note — the poll flips `brewMissing` the moment
+            // brew resolves and the normal UI takes over by itself.
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Waiting for Homebrew… the app continues automatically once it's installed.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Re-check brew + the CLT every 2s while this pane is up. SwiftUI
+        // cancels the task with the view, so nothing polls after onboarding.
+        .task { await model.pollForBrew() }
+    }
+
+    /// One numbered step: title, secondary detail, and the command in a
+    /// selectable monospaced row with a Copy button. Stock `GroupBox` chrome.
+    private func step(number: Int, title: String, detail: String, command: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("\(number). \(title)")
+                .font(.headline)
+            Text(detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            GroupBox {
+                HStack(spacing: 12) {
+                    Text(command)
+                        .font(.callout)
+                        .monospaced()
+                        .textSelection(.enabled)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button {
+                        copyToPasteboard(command)
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .help("Copy the command to the clipboard")
+                }
+                .padding(4)
+            }
+        }
+    }
+
+    /// Copy a fixed command string to the general pasteboard (same NSPasteboard
+    /// usage as the GitHub device-flow code copy in AppModel).
+    private func copyToPasteboard(_ command: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(command, forType: .string)
+    }
+
+    /// Open Terminal.app via its FIXED bundle identifier — a constant Launch
+    /// Services lookup with zero string interpolation (no AppleScript, no shell).
+    private func openTerminal() {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.Terminal") else { return }
+        NSWorkspace.shared.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
+    }
+}
+
+#if DEBUG
+#Preview("Onboarding — no CLT") {
+    OnboardingView(model: AppModel())
+        .frame(width: 820, height: 640)
+}
+#endif

--- a/native/Sources/BrewBrowserKit/VulnsService.swift
+++ b/native/Sources/BrewBrowserKit/VulnsService.swift
@@ -137,9 +137,10 @@ struct VulnExposure: Sendable, Hashable {
 
 // MARK: - Errors
 
-/// Errors surfaced by ``VulnsService``. Self-contained (does not reuse
-/// `BrewService`'s `BrewError`) so this file stands alone, per the
-/// task constraint of touching only this file.
+/// Errors surfaced by ``VulnsService``. Its own type (not `BrewService`'s
+/// `BrewError`) so a vulns failure is distinguishable at the call site —
+/// `.brewNotFound` here is the honest "no Homebrew" signal where the old
+/// code fabricated a default brew path and mis-probed instead.
 enum VulnsServiceError: Error, LocalizedError {
     case brewNotFound
     /// Real scan failure — exit code ≥ 2 (exit 0/1 are NOT failures, see
@@ -188,27 +189,24 @@ struct VulnsService: Sendable {
     /// `BREW_VULNS_INSTALL_CMD`).
     static let installCommand = "brew install homebrew/brew-vulns/brew-vulns"
 
-    /// Resolved path to the brew binary.
-    private let brewPath: String
+    /// Resolved path to the brew binary, or nil when no Homebrew install was
+    /// found. Internal (not private) so tests can assert it mirrors the shared
+    /// resolver exactly — a nil resolution must stay nil, never be papered
+    /// over with a fabricated default path (the old `/opt/homebrew/bin/brew`
+    /// fallback silently mis-probed Intel/brew-less machines).
+    let brewPath: String?
 
     /// Inject a resolved brew path (testing / explicit configuration).
-    init(brewPath: String) {
+    /// nil = "no brew" — every scan/probe call then surfaces `.brewNotFound`.
+    init(brewPath: String?) {
         self.brewPath = brewPath
     }
 
-    /// Resolve the brew binary the way the Rust backend does: prefer the
-    /// Apple-Silicon prefix, fall back to the Intel path. Non-throwing so it
-    /// can be a stored property; if neither path exists we keep the Apple-
-    /// Silicon default and the scan/probe calls simply report not-installed.
+    /// Resolve via the shared `BrewService.resolveBrewPath()` (Apple-Silicon
+    /// prefix, then Intel). Non-throwing so it can be a stored property; a nil
+    /// resolution is kept as-is and surfaces as `.brewNotFound` at call time.
     init() {
-        self.brewPath = Self.resolveBrewPath() ?? "/opt/homebrew/bin/brew"
-    }
-
-    /// Prefer `/opt/homebrew/bin/brew` (Apple Silicon), fall back to
-    /// `/usr/local/bin/brew` (Intel).
-    private static func resolveBrewPath() -> String? {
-        let candidates = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+        self.brewPath = BrewService.resolveBrewPath()
     }
 
     // MARK: Install detection
@@ -330,6 +328,7 @@ struct VulnsService: Sendable {
     /// can apply the right exit-code policy per command (GOTCHA #1: scans
     /// treat exit 1 as success; install does not).
     private func run(_ args: [String]) throws -> ProcessResult {
+        guard let brewPath else { throw VulnsServiceError.brewNotFound }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: brewPath)
         process.arguments = args

--- a/native/Tests/BrewBrowserKitTests/OnboardingStateTests.swift
+++ b/native/Tests/BrewBrowserKitTests/OnboardingStateTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import BrewBrowserKit
+
+// Tests for the missing-Homebrew onboarding gate — the AppModel state machine
+// behind OnboardingView. The poll loop's per-pass logic lives in
+// `updateOnboarding(brewFound:cltFound:)` precisely so these transitions are
+// drivable without a real (or really-missing) Homebrew install.
+
+@Suite("Missing-Homebrew onboarding state")
+@MainActor
+struct OnboardingStateTests {
+    @Test func missingResolutionStaysInOnboarding() {
+        let model = AppModel()
+        model.brewMissing = true   // simulate a failed launch resolution
+
+        // A poll pass with brew still missing keeps onboarding up and tracks
+        // the CLT probe for the step list.
+        #expect(model.updateOnboarding(brewFound: false, cltFound: false) == false)
+        #expect(model.brewMissing)
+        #expect(!model.cltInstalled)
+    }
+
+    @Test func cltProbeUpdatesIndependentlyOfBrew() {
+        let model = AppModel()
+        model.brewMissing = true
+
+        // CLT lands first (the installer prompt finished) while brew is still
+        // installing — the step list updates, onboarding stays up.
+        #expect(model.updateOnboarding(brewFound: false, cltFound: true) == false)
+        #expect(model.brewMissing)
+        #expect(model.cltInstalled)
+    }
+
+    @Test func brewFoundExitsOnboarding() {
+        let model = AppModel()
+        model.brewMissing = true
+
+        // The pass where brew resolves ends onboarding (true = stop polling);
+        // ContentView then builds the normal root, whose `.task`s run the
+        // standard initial load sequence.
+        #expect(model.updateOnboarding(brewFound: true, cltFound: true))
+        #expect(!model.brewMissing)
+    }
+
+    @Test func brewFoundStaysExitedOnLaterPasses() {
+        let model = AppModel()
+        model.brewMissing = true
+        model.updateOnboarding(brewFound: true, cltFound: true)
+
+        // A stray extra pass (e.g. an in-flight probe finishing late) must not
+        // flip the app back into onboarding.
+        #expect(model.updateOnboarding(brewFound: true, cltFound: true))
+        #expect(!model.brewMissing)
+    }
+
+    @Test func initialResolutionMatchesSharedResolver() {
+        // The launch gate keys off the same shared resolver as the services:
+        // brewMissing at init is exactly "resolution returned nil".
+        let model = AppModel()
+        #expect(model.brewMissing == (BrewService.resolveBrewPath() == nil))
+    }
+}

--- a/native/Tests/BrewBrowserKitTests/VulnsParsingTests.swift
+++ b/native/Tests/BrewBrowserKitTests/VulnsParsingTests.swift
@@ -87,3 +87,35 @@ struct VulnsParseTests {
         }
     }
 }
+
+@Suite("VulnsService brew resolution")
+struct VulnsResolutionTests {
+    // The regression we guard: a failed resolution used to be papered over
+    // with a hardcoded "/opt/homebrew/bin/brew". The default init must carry
+    // exactly what the shared resolver returns — including nil.
+    @Test func defaultInitNeverFabricatesAPath() {
+        #expect(VulnsService().brewPath == BrewService.resolveBrewPath())
+    }
+
+    @Test func nilBrewPathSurfacesBrewNotFound() async {
+        let service = VulnsService(brewPath: nil)
+        do {
+            _ = try await service.scanOne(name: "wget", isCask: false)
+            Issue.record("scanOne should throw .brewNotFound when no brew path resolved")
+        } catch let error as VulnsServiceError {
+            guard case .brewNotFound = error else {
+                Issue.record("expected .brewNotFound, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("expected VulnsServiceError.brewNotFound, got \(error)")
+        }
+    }
+
+    @Test func nilBrewPathReportsHelperNotInstalled() async {
+        // The install probe is best-effort (`try?`) — with no brew it must
+        // report not-installed, never crash or pretend a probe ran.
+        let service = VulnsService(brewPath: nil)
+        #expect(await service.isBrewVulnsInstalled() == false)
+    }
+}

--- a/native/build-app.sh
+++ b/native/build-app.sh
@@ -3,17 +3,31 @@
 # launches as a real, activatable Mac app (SPM alone produces a bare binary
 # with no Info.plist, which macOS treats as a background process).
 #
-# Usage: native/build-app.sh [debug|release]   (default: debug)
+# Usage: native/build-app.sh [debug|release] [arm64|x86_64]   (default: debug, host arch)
+#        The arch may also come from the ARCH env var; the positional arg wins.
+#        No arch given = no --arch flag = exactly the historical host (arm64)
+#        build. x86_64 native covers ONLY the four Intel Macs that run macOS 26
+#        (MBP 16" 2019, MBP 13" 2020 4-port, iMac 27" 2020, Mac Pro 2019).
 set -euo pipefail
 
 CONFIG="${1:-debug}"
+ARCH="${2:-${ARCH:-}}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 cd "$HERE"
 
-echo "==> swift build ($CONFIG)"
-swift build -c "$CONFIG"
-
-BINDIR="$(swift build -c "$CONFIG" --show-bin-path)"
+# With an explicit --arch, SwiftPM emits to .build/<arch>-apple-macosx/<config>/
+# instead of .build/<config>/ — so BINDIR (which the binary copy, the resource-
+# bundle glob, and the Sparkle.framework path below all hang off) MUST come from
+# --show-bin-path with the same flags as the build itself.
+if [ -n "$ARCH" ]; then
+  echo "==> swift build ($CONFIG, $ARCH)"
+  swift build -c "$CONFIG" --arch "$ARCH"
+  BINDIR="$(swift build -c "$CONFIG" --arch "$ARCH" --show-bin-path)"
+else
+  echo "==> swift build ($CONFIG)"
+  swift build -c "$CONFIG"
+  BINDIR="$(swift build -c "$CONFIG" --show-bin-path)"
+fi
 BIN="$BINDIR/BrewBrowser"
 APP="$HERE/BrewBrowser.app"
 

--- a/native/release.sh
+++ b/native/release.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
-# native/release.sh — produce a SIGNED, NOTARIZED, Sparkle-ready release of the
-# native app, then generate the appcast. Run on the maintainer's Mac — the one
-# holding the Apple "Developer ID Application" cert AND the Sparkle private key
-# in its login Keychain (created once by `generate_keys`; its public half is the
-# SUPublicEDKey baked into build-app.sh's Info.plist).
+# native/release.sh — produce SIGNED, NOTARIZED, Sparkle-ready releases of the
+# native app for BOTH arches (separate arm64 and x86_64 builds — deliberately
+# NOT a universal binary), then generate the appcast. Run on the maintainer's
+# Mac — the one holding the Apple "Developer ID Application" cert AND the
+# Sparkle private key in its login Keychain (created once by `generate_keys`;
+# its public half is the SUPublicEDKey baked into build-app.sh's Info.plist).
 #
-# Flow: build(release) → Developer ID sign (hardened runtime) → zip → notarize →
-#       staple → re-zip → generate_appcast (signs each update with the Sparkle
-#       private key) → appcast.xml. Then you upload the zip + appcast.xml to the
-#       path behind the public SUFeedURL (brew-browser.zerologic.com/...).
+# x86_64 native covers ONLY the four Intel Macs that run macOS 26
+# (MBP 16" 2019, MBP 13" 2020 4-port, iMac 27" 2020, Mac Pro 2019).
+#
+# Flow: per arch [ build(release, arch) → Developer ID sign (hardened runtime)
+#       → zip BrewBrowser-$VERSION-<arch>.zip → notarize → staple → re-zip ]
+#       → generate_appcast ONCE over $OUT_DIR (zips only; signs each update
+#       with the Sparkle private key) → appcast.xml → per-arch dmgs.
+#       Then you upload the zips + appcast.xml to the path behind the public
+#       SUFeedURL (brew-browser.zerologic.com/...).
+#
+# Ordering is load-bearing: generate_appcast scans $OUT_DIR and treats every
+# archive it finds as an update — so the dmgs (first-install download, not a
+# Sparkle artifact) are built AFTER the appcast AND live in $OUT_DIR/dmg/, a
+# subdir generate_appcast never scans. That also fixes the old bug where dmgs
+# left in $OUT_DIR polluted the NEXT release's appcast scan.
 #
 # Required env:
 #   DEVELOPER_ID_APP   e.g. "Developer ID Application: Your Name (TEAMID)"
@@ -37,66 +49,116 @@ SPARKLE_BIN="$HERE/.build/artifacts/sparkle/Sparkle/bin"
 APP="$HERE/BrewBrowser.app"
 [ -x "$SPARKLE_BIN/generate_appcast" ] || { echo "Sparkle tools missing — run 'swift build' first."; exit 1; }
 
-echo "==> build (release) + assemble"
-./build-app.sh release
+ARCHES=(arm64 x86_64)
+DMG_DIR="$OUT_DIR/dmg"
+mkdir -p "$OUT_DIR" "$DMG_DIR"
 
-VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist")"
-echo "==> version $VERSION"
+# Stapled per-arch .apps are kept here until the dmgs are built — build-app.sh
+# overwrites BrewBrowser.app on every run, so the arm64 app must survive the
+# x86_64 build (and both must survive until after generate_appcast).
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
 
-# Developer ID sign, inside-out, with the hardened runtime (notarization needs
-# it). Nested Sparkle code (XPC services, Updater.app, Autoupdate) + the bundled
-# SwiftPM resource bundles must be signed before the framework / app that contain
-# them. The ad-hoc signature build-app.sh applied is replaced here.
-echo "==> Developer ID sign"
-SIGN=(codesign --force --options runtime --timestamp --sign "$DEVELOPER_ID_APP")
-FW="$APP/Contents/Frameworks/Sparkle.framework"
-if [ -d "$FW" ]; then
-  find "$FW" -type d \( -name "*.xpc" -o -name "*.app" \) -print0 \
-    | xargs -0 -I{} "${SIGN[@]}" "{}"
-  [ -f "$FW/Versions/Current/Autoupdate" ] && "${SIGN[@]}" "$FW/Versions/Current/Autoupdate"
-  "${SIGN[@]}" "$FW"
-fi
-for b in "$APP"/Contents/Resources/*.bundle; do [ -e "$b" ] && "${SIGN[@]}" "$b"; done
-"${SIGN[@]}" "$APP"
-codesign --verify --deep --strict --verbose=2 "$APP"
+VERSION=""
+for arch in "${ARCHES[@]}"; do
+  echo "==> [$arch] build (release) + assemble"
+  ./build-app.sh release "$arch"
 
-mkdir -p "$OUT_DIR"
-ZIP="$OUT_DIR/BrewBrowser-$VERSION.zip"
-echo "==> zip $ZIP"
-rm -f "$ZIP"
-ditto -c -k --keepParent "$APP" "$ZIP"
+  V="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist")"
+  if [ -z "$VERSION" ]; then
+    VERSION="$V"
+    echo "==> version $VERSION"
+  elif [ "$V" != "$VERSION" ]; then
+    echo "version mismatch across arches ($VERSION vs $V)"; exit 1
+  fi
 
-echo "==> notarize (waits for Apple)"
-xcrun notarytool submit "$ZIP" --keychain-profile "$NOTARY_PROFILE" --wait
-echo "==> staple"
-xcrun stapler staple "$APP"
-rm -f "$ZIP"                       # re-zip so the download carries the ticket
-ditto -c -k --keepParent "$APP" "$ZIP"
+  # Developer ID sign, inside-out, with the hardened runtime (notarization needs
+  # it). Nested Sparkle code (XPC services, Updater.app, Autoupdate) + the bundled
+  # SwiftPM resource bundles must be signed before the framework / app that contain
+  # them. The ad-hoc signature build-app.sh applied is replaced here.
+  echo "==> [$arch] Developer ID sign"
+  SIGN=(codesign --force --options runtime --timestamp --sign "$DEVELOPER_ID_APP")
+  FW="$APP/Contents/Frameworks/Sparkle.framework"
+  if [ -d "$FW" ]; then
+    find "$FW" -type d \( -name "*.xpc" -o -name "*.app" \) -print0 \
+      | xargs -0 -I{} "${SIGN[@]}" "{}"
+    [ -f "$FW/Versions/Current/Autoupdate" ] && "${SIGN[@]}" "$FW/Versions/Current/Autoupdate"
+    "${SIGN[@]}" "$FW"
+  fi
+  for b in "$APP"/Contents/Resources/*.bundle; do [ -e "$b" ] && "${SIGN[@]}" "$b"; done
+  "${SIGN[@]}" "$APP"
+  codesign --verify --deep --strict --verbose=2 "$APP"
 
-# Disk image for FIRST-INSTALL download (humans prefer a .dmg; Sparkle uses the
-# .zip above for auto-updates). Built from the stapled .app, staged with an
-# /Applications symlink for drag-to-install, then Developer-ID signed +
-# notarized + stapled — same treatment as the Tauri build's .dmg.
-DMG="$OUT_DIR/BrewBrowser-$VERSION.dmg"
-echo "==> dmg $DMG"
-STAGE="$(mktemp -d)"
-cp -R "$APP" "$STAGE/"
-ln -s /Applications "$STAGE/Applications"
-rm -f "$DMG"
-hdiutil create -volname "Brew Browser" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
-rm -rf "$STAGE"
-codesign --force --timestamp --sign "$DEVELOPER_ID_APP" "$DMG"
-echo "==> notarize dmg (waits for Apple)"
-xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
-xcrun stapler staple "$DMG"
+  ZIP="$OUT_DIR/BrewBrowser-$VERSION-$arch.zip"
+  echo "==> [$arch] zip $ZIP"
+  rm -f "$ZIP"
+  ditto -c -k --keepParent "$APP" "$ZIP"
 
+  echo "==> [$arch] notarize (waits for Apple)"
+  xcrun notarytool submit "$ZIP" --keychain-profile "$NOTARY_PROFILE" --wait
+  echo "==> [$arch] staple"
+  xcrun stapler staple "$APP"
+  rm -f "$ZIP"                     # re-zip so the download carries the ticket
+  ditto -c -k --keepParent "$APP" "$ZIP"
+
+  # Park the stapled .app for the dmg pass (after generate_appcast).
+  mkdir -p "$WORK/$arch"
+  cp -R "$APP" "$WORK/$arch/BrewBrowser.app"
+done
+
+# generate_appcast runs ONCE over $OUT_DIR, which at this point holds ONLY the
+# .zips (this release's two arches + prior releases' history) — the dmgs don't
+# exist yet and land in $DMG_DIR, which it never scans. Sparkle emits
+# sparkle:hardwareRequirements per archive, which is how two same-version items
+# (one per arch) coexist in one feed (the 0.1.0 appcast demonstrated this).
 echo "==> generate appcast (signs with the Sparkle private key in your Keychain)"
 "$SPARKLE_BIN/generate_appcast" --download-url-prefix "$DOWNLOAD_URL_PREFIX" "$OUT_DIR"
 
+# Disk images for FIRST-INSTALL download (humans prefer a .dmg; Sparkle uses the
+# .zips above for auto-updates). Built from the stapled per-arch .apps, staged
+# with an /Applications symlink for drag-to-install, then Developer-ID signed +
+# notarized + stapled — same treatment as the Tauri build's .dmg.
+for arch in "${ARCHES[@]}"; do
+  DMG="$DMG_DIR/BrewBrowser-$VERSION-$arch.dmg"
+  echo "==> [$arch] dmg $DMG"
+  STAGE="$WORK/dmg-$arch"
+  mkdir -p "$STAGE"
+  cp -R "$WORK/$arch/BrewBrowser.app" "$STAGE/"
+  ln -s /Applications "$STAGE/Applications"
+  rm -f "$DMG"
+  hdiutil create -volname "Brew Browser" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
+  codesign --force --timestamp --sign "$DEVELOPER_ID_APP" "$DMG"
+  echo "==> [$arch] notarize dmg (waits for Apple)"
+  xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun stapler staple "$DMG"
+done
+
+# Post-run sanity: the appcast must carry ONE item per arch for this version,
+# each with sparkle:hardwareRequirements — that's how a single feed serves both
+# arches. Counted here so a bad feed never ships silently.
+APPCAST="$OUT_DIR/appcast.xml"
+ITEM_COUNT="$(grep -c "BrewBrowser-$VERSION-" "$APPCAST" 2>/dev/null || true)"
+HW_COUNT="$(grep -c "sparkle:hardwareRequirements" "$APPCAST" 2>/dev/null || true)"
+
 echo
 echo "==> done."
+echo "   Post-run checklist:"
+echo "   [ ] appcast.xml has one <item> per arch for $VERSION (found $ITEM_COUNT enclosure(s) matching BrewBrowser-$VERSION-<arch>.zip)"
+echo "   [ ] each item carries sparkle:hardwareRequirements (found $HW_COUNT in the feed)"
+echo "   [ ] spot-check: grep -A3 \"BrewBrowser-$VERSION-\" \"$APPCAST\""
+if [ "${ITEM_COUNT:-0}" -lt 2 ] || [ "${HW_COUNT:-0}" -lt 2 ]; then
+  echo
+  echo "   ############################################################################"
+  echo "   ## WARNING: appcast.xml does NOT look right for a dual-arch release.      ##"
+  echo "   ## generate_appcast may have collapsed/dropped the two same-version zips. ##"
+  echo "   ## FALLBACK PLAN: dual feeds — generate appcast-arm64.xml and             ##"
+  echo "   ## appcast-x86_64.xml from per-arch zip dirs, and have build-app.sh bake  ##"
+  echo "   ## a per-arch SUFeedURL into Info.plist. Do NOT ship this appcast as-is.  ##"
+  echo "   ############################################################################"
+fi
+echo
 echo "   Upload to the host (path behind $DOWNLOAD_URL_PREFIX) — Sparkle auto-update feed:"
-ls -1 "$OUT_DIR"/BrewBrowser-*.zip "$OUT_DIR/appcast.xml"
+ls -1 "$OUT_DIR"/BrewBrowser-"$VERSION"-*.zip "$APPCAST"
 echo "   (appcast.xml must be served at the SUFeedURL in build-app.sh's Info.plist)"
-echo "   Attach to the GitHub release (first-install download):"
-ls -1 "$OUT_DIR"/BrewBrowser-*.dmg
+echo "   Attach to the GitHub release (first-install downloads, per arch):"
+ls -1 "$DMG_DIR"/BrewBrowser-"$VERSION"-*.dmg

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +553,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -750,6 +789,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +856,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1582,6 +1640,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +1947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,7 +2135,9 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "dbus-secret-service",
  "log",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "zeroize",
@@ -2278,6 +2366,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,10 +2388,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2920,7 +3085,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2969,12 +3134,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2984,7 +3170,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3387,6 +3582,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,6 +3836,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3760,6 +3985,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -4120,7 +4351,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
- "zbus",
+ "zbus 5.15.0",
 ]
 
 [[package]]
@@ -5868,6 +6099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5888,6 +6129,38 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5920,9 +6193,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.15.0",
+ "zbus_names 4.3.2",
+ "zvariant 5.11.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5935,9 +6221,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.2",
+ "zvariant 5.11.0",
+ "zvariant_utils 3.3.1",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5948,7 +6245,7 @@ checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
  "winnow 1.0.3",
- "zvariant",
+ "zvariant 5.11.0",
 ]
 
 [[package]]
@@ -5997,6 +6294,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -6051,6 +6362,19 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
@@ -6059,8 +6383,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 1.0.3",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.11.0",
+ "zvariant_utils 3.3.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -6073,7 +6410,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.1",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,12 +69,6 @@ flate2 = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# OS-native secret storage. Phase 12e (GitHub Device Flow) stores the
-# OAuth access token in the macOS Keychain under
-# `com.zerologic.brew-browser` / `github_access_token`. The crate fans out to
-# Keychain on macOS, Credential Manager on Windows, Secret Service on
-# Linux — we only use the macOS path.
-keyring = { version = "3", features = ["apple-native"] }
 # URL-encoded form bodies for the GitHub Device Flow endpoints.
 # `serde_urlencoded` is already pulled in transitively by `reqwest`
 # but `url` (parsing) is not. Keep this dep tight.
@@ -83,12 +77,32 @@ url = "2"
 # Native macOS window vibrancy (NSVisualEffectView) — gives the sidebar that
 # "frosted glass" look the rest of macOS uses. Cross-platform crate; we only
 # call its macOS APIs.
+#
+# OS-native secret storage. Phase 12e (GitHub Device Flow) stores the
+# OAuth access token under `com.zerologic.brew-browser` /
+# `github_access_token`. The `keyring` crate exposes a single unified
+# `Entry` / `Error` API (`github/auth.rs::SystemKeychain`) regardless of
+# backend, so only the Cargo feature set is platform-specific:
+#   - macOS  → `apple-native` (Security framework / Keychain).
+#   - Linux  → `sync-secret-service` (persistent across reboot, backed by
+#     gnome-keyring / kwallet via the Secret Service D-Bus API — NOT the
+#     session-scoped kernel keyutils) + `crypto-rust` (pure-Rust AES, so
+#     no system OpenSSL build dependency on CI). See the Linux target
+#     section below.
 [target.'cfg(target_os = "macos")'.dependencies]
 window-vibrancy = "0.6"
+keyring = { version = "3", features = ["apple-native"] }
 # Direct use of the Security framework for a single batched Keychain read
 # (one SecItemCopyMatching for all GitHub items → one auth prompt instead of
 # three). Pinned to "2" to unify with the version keyring already compiles.
 security-framework = "2"
+
+# Linux secret storage. Secret Service requires a running daemon
+# (gnome-keyring / kwallet); on a headless box or a minimal WM without
+# one, GitHub sign-in fails closed via `BrewError::KeychainUnavailable`
+# (the rest of the app is unaffected). See `github/auth.rs`.
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 
 [dev-dependencies]
 # Reserved for future integration tests that need a sandbox dir

--- a/src-tauri/src/brew/exec.rs
+++ b/src-tauri/src/brew/exec.rs
@@ -35,6 +35,24 @@ pub type JobsMap = Arc<Mutex<HashMap<Uuid, JobHandle>>>;
 ///
 /// On non-zero exit, returns `BrewError::BrewExitNonZero` with the last
 /// ~4 KB of stderr. The `display_command` string is the user-facing form.
+/// A directory that is guaranteed to exist and be readable by the
+/// invoking user on every supported platform. We set this as the
+/// working directory for every `brew` subprocess.
+///
+/// **Why:** Homebrew refuses to run when its current working directory
+/// isn't readable by the user — on Linux it aborts with "The current
+/// working directory must be readable to <user> to run brew." A GUI app
+/// inherits whatever cwd it was launched from (the app-launcher's cwd,
+/// a stale deleted directory, or — when launched oddly — a root-owned
+/// path the user can't read). Pinning every spawn to `/` makes the brew
+/// invocation independent of how the app happened to be launched. `/`
+/// is world-readable on macOS and Linux and always exists.
+///
+/// Discovered during the v0.6.0 Linux bring-up: launching the app from
+/// a directory the user couldn't read made every `brew info` fail with
+/// the readable-cwd error, surfacing as "Couldn't load packages."
+const BREW_SPAWN_CWD: &str = "/";
+
 pub async fn run_brew_capture(
     brew_path: &Path,
     args: &[&str],
@@ -42,6 +60,7 @@ pub async fn run_brew_capture(
 ) -> Result<String, BrewError> {
     let mut cmd = Command::new(brew_path);
     cmd.args(args)
+        .current_dir(BREW_SPAWN_CWD)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -99,6 +118,7 @@ pub async fn run_brew_streaming(
 
     let mut cmd = Command::new(brew_path);
     cmd.args(&str_args)
+        .current_dir(BREW_SPAWN_CWD)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src-tauri/src/brew/paths.rs
+++ b/src-tauri/src/brew/paths.rs
@@ -2,21 +2,42 @@
 
 use std::path::PathBuf;
 
-/// Resolve the path to the `brew` binary by checking the known prefixes
-/// (Apple Silicon first, then Intel), then falling back to a PATH lookup.
+/// Resolve the path to the `brew` binary by checking the known prefixes,
+/// then falling back to a PATH lookup.
+///
+/// Order: macOS Apple Silicon (`/opt/homebrew`), macOS Intel
+/// (`/usr/local`), Linuxbrew shared install
+/// (`/home/linuxbrew/.linuxbrew`), Linuxbrew per-user install
+/// (`~/.linuxbrew`). The prefixes are checked unconditionally rather than
+/// `#[cfg]`-gated by OS: the `is_file()` guard makes a macOS prefix
+/// harmless on Linux (and vice versa), and an explicit list avoids
+/// relying on the PATH fallback — a GUI-launched app inherits a minimal
+/// PATH that often omits the Homebrew bin dir.
 ///
 /// Returns `None` if brew can't be located. Callers should map this to
 /// `BrewError::BrewNotFound`.
 pub fn resolve_brew_path() -> Option<PathBuf> {
-    // Apple Silicon default
+    // macOS Apple Silicon default
     let arm = PathBuf::from("/opt/homebrew/bin/brew");
     if arm.is_file() {
         return Some(arm);
     }
-    // Intel default
+    // macOS Intel default
     let intel = PathBuf::from("/usr/local/bin/brew");
     if intel.is_file() {
         return Some(intel);
+    }
+    // Linuxbrew shared install (default for the official install script).
+    let linux_shared = PathBuf::from("/home/linuxbrew/.linuxbrew/bin/brew");
+    if linux_shared.is_file() {
+        return Some(linux_shared);
+    }
+    // Linuxbrew per-user install (~/.linuxbrew/bin/brew).
+    if let Some(home) = dirs::home_dir() {
+        let linux_user = home.join(".linuxbrew").join("bin").join("brew");
+        if linux_user.is_file() {
+            return Some(linux_user);
+        }
     }
     // PATH fallback
     if let Ok(path_var) = std::env::var("PATH") {
@@ -66,6 +87,24 @@ mod tests {
                 resolve_brew_path().as_deref(),
                 Some(arm.as_path()),
                 "must prefer /opt/homebrew/bin/brew over PATH lookup"
+            );
+        }
+    }
+
+    /// On a Linuxbrew host where the shared install exists, the resolver
+    /// must return it verbatim. Mirrors the Apple-Silicon test: it can't
+    /// override the filesystem, so it only asserts when the path is
+    /// actually present (a no-op on macOS CI / dev hosts).
+    #[test]
+    fn resolve_brew_path_finds_linuxbrew_shared_when_present() {
+        let shared = std::path::PathBuf::from("/home/linuxbrew/.linuxbrew/bin/brew");
+        if shared.is_file() {
+            // The macOS prefixes won't exist on a Linux box, so the
+            // shared Linuxbrew prefix is the first explicit hit.
+            assert_eq!(
+                resolve_brew_path().as_deref(),
+                Some(shared.as_path()),
+                "must resolve /home/linuxbrew/.linuxbrew/bin/brew when no macOS prefix exists"
             );
         }
     }

--- a/src-tauri/src/commands/cask_icon.rs
+++ b/src-tauri/src/commands/cask_icon.rs
@@ -36,13 +36,23 @@ use std::time::{Duration, SystemTime};
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine as _;
 use tauri::State;
-use tokio::process::Command;
 
-use crate::brew::exec::run_brew_capture;
-use crate::brew::parse::RawInfoV2;
 use crate::commands::info::validate_cask_token;
-use crate::error::{truncate_head, BrewError};
+use crate::error::BrewError;
 use crate::state::AppState;
+
+// macOS-only: the `.app`-bundle icon extraction pipeline (defaults/sips
+// shell-outs, brew-info resolution, .icns discovery). These symbols are
+// unused on non-macOS targets where `cask_icon` short-circuits to
+// `Ok(None)`, so gate them to avoid dead-code warnings on the Linux build.
+#[cfg(target_os = "macos")]
+use tokio::process::Command;
+#[cfg(target_os = "macos")]
+use crate::brew::exec::run_brew_capture;
+#[cfg(target_os = "macos")]
+use crate::brew::parse::RawInfoV2;
+#[cfg(target_os = "macos")]
+use crate::error::truncate_head;
 
 /// Cache TTL — re-extract if the cached PNG is older than this.
 const ICON_CACHE_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
@@ -72,27 +82,42 @@ pub async fn cask_icon(
         return Ok(Some(data_url));
     }
 
-    // Resolve the .app bundle. None → cask not installed or no `app`
-    // artifact (common for pkg / binary-only casks). Return Ok(None).
-    let app_path = match resolve_app_path(&state, &token).await? {
-        Some(p) => p,
-        None => return Ok(None),
-    };
+    // `.app`-bundle icon extraction is macOS-only — it shells out to the
+    // macOS-native `/usr/bin/defaults` and `/usr/bin/sips` and walks the
+    // `Contents/Resources/*.icns` bundle layout. Linux casks don't
+    // produce `.app` bundles, so the `IconSource` routing won't even
+    // select this path; we short-circuit to `Ok(None)` here anyway as
+    // defense in depth, so we never attempt to spawn binaries that don't
+    // exist on Linux.
+    #[cfg(target_os = "macos")]
+    {
+        // Resolve the .app bundle. None → cask not installed or no `app`
+        // artifact (common for pkg / binary-only casks). Return Ok(None).
+        let app_path = match resolve_app_path(&state, &token).await? {
+            Some(p) => p,
+            None => return Ok(None),
+        };
 
-    // Find the .icns file inside the bundle. None → unbundled app or
-    // some app shipping non-standard resources. Return Ok(None).
-    let icns_path = match find_icns(&app_path).await {
-        Some(p) => p,
-        None => return Ok(None),
-    };
+        // Find the .icns file inside the bundle. None → unbundled app or
+        // some app shipping non-standard resources. Return Ok(None).
+        let icns_path = match find_icns(&app_path).await {
+            Some(p) => p,
+            None => return Ok(None),
+        };
 
-    // Convert .icns → cached PNG. sips failure is a real error
-    // (sips ships with macOS; missing or crashing it is genuinely
-    // exceptional).
-    sips_convert_to_png(&icns_path, &cache_path).await?;
+        // Convert .icns → cached PNG. sips failure is a real error
+        // (sips ships with macOS; missing or crashing it is genuinely
+        // exceptional).
+        sips_convert_to_png(&icns_path, &cache_path).await?;
 
-    // Read back, encode, return.
-    encode_png_as_data_url(&cache_path).await.map(Some)
+        // Read back, encode, return.
+        encode_png_as_data_url(&cache_path).await.map(Some)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(None)
+    }
 }
 
 // ---------- Cache layer ----------
@@ -144,6 +169,7 @@ fn ensure_dir(dir: &Path) -> Result<(), BrewError> {
 
 /// Return the absolute path to the cask's `.app` bundle, or `None` if
 /// the cask isn't installed / has no `app` artifact.
+#[cfg(target_os = "macos")]
 async fn resolve_app_path(
     state: &State<'_, AppState>,
     token: &str,
@@ -193,6 +219,7 @@ async fn resolve_app_path(
 /// Walk `artifacts[].app[]` and return the first string entry. Brew
 /// sometimes serializes `app` as `["Firefox.app"]`, sometimes as
 /// `[{"target": "Firefox.app", "source": "..."}]`; handle both.
+#[cfg(target_os = "macos")]
 fn first_app_filename(artifacts: &Option<serde_json::Value>) -> Option<String> {
     let arr = artifacts.as_ref()?.as_array()?;
     for entry in arr {
@@ -225,6 +252,7 @@ fn first_app_filename(artifacts: &Option<serde_json::Value>) -> Option<String> {
 /// Given an `.app` filename like `"Firefox.app"`, return the first of
 /// `/Applications/<name>` or `~/Applications/<name>` that exists.
 /// Returns `None` if neither does.
+#[cfg(target_os = "macos")]
 fn resolve_app_bundle(filename: &str) -> Option<PathBuf> {
     // Filename safety — must end with `.app` and not contain path
     // separators (so we don't accidentally resolve into a parent dir).
@@ -255,6 +283,7 @@ fn resolve_app_bundle(filename: &str) -> Option<PathBuf> {
 ///
 /// `read_bundle_icon_file` is unchanged — `defaults read` happily
 /// reads any plist path; the gate is the *use* of its return value.
+#[cfg(target_os = "macos")]
 async fn find_icns(app_path: &Path) -> Option<PathBuf> {
     let info_plist = app_path.join("Contents").join("Info.plist");
     let resources = app_path.join("Contents").join("Resources");
@@ -301,6 +330,7 @@ async fn find_icns(app_path: &Path) -> Option<PathBuf> {
 /// Both sides are canonicalized so that a symlink farm pointing back
 /// into `resources` from an external location is still detected as a
 /// traversal — we compare resolved physical paths, not lexical paths.
+#[cfg(target_os = "macos")]
 fn safe_join_in_resources(resources: &Path, candidate: &str) -> Option<PathBuf> {
     // Reject obvious lexical traversal before touching the disk —
     // canonicalize would either resolve out or fail, but a quick
@@ -320,6 +350,7 @@ fn safe_join_in_resources(resources: &Path, candidate: &str) -> Option<PathBuf> 
 /// Shell out to `defaults read <Info.plist> CFBundleIconFile`. Returns
 /// `None` when the key is absent or `defaults` exits non-zero (binary
 /// plists are still readable by `defaults`).
+#[cfg(target_os = "macos")]
 async fn read_bundle_icon_file(info_plist: &Path) -> Option<String> {
     // `defaults read` wants the path without the trailing `.plist`.
     let arg = info_plist
@@ -343,6 +374,7 @@ async fn read_bundle_icon_file(info_plist: &Path) -> Option<String> {
     }
 }
 
+#[cfg(target_os = "macos")]
 async fn first_icns_in_dir(dir: &Path) -> Option<PathBuf> {
     let mut rd = tokio::fs::read_dir(dir).await.ok()?;
     // Read all entries first so we can sort for determinism.
@@ -361,6 +393,7 @@ async fn first_icns_in_dir(dir: &Path) -> Option<PathBuf> {
 
 // ---------- sips conversion ----------
 
+#[cfg(target_os = "macos")]
 async fn sips_convert_to_png(input: &Path, output: &Path) -> Result<(), BrewError> {
     // sips: macOS-native, no extra deps. Resize to ICON_PIXELS square.
     let out = Command::new("/usr/bin/sips")
@@ -400,6 +433,8 @@ async fn sips_convert_to_png(input: &Path, output: &Path) -> Result<(), BrewErro
 mod tests {
     use super::*;
     use crate::commands::info::validate_package_name;
+    // `json!` is only used by the macOS-gated `first_app_filename` tests.
+    #[cfg(target_os = "macos")]
     use serde_json::json;
 
     // ---------- token validation reuse ----------
@@ -438,8 +473,9 @@ mod tests {
         assert!(validate_cask_token(".").is_err());
     }
 
-    // ---------- first_app_filename ----------
+    // ---------- first_app_filename (macOS-only: gated with the fn) ----------
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn first_app_filename_handles_string_form() {
         let artifacts = Some(json!([
@@ -448,6 +484,7 @@ mod tests {
         assert_eq!(first_app_filename(&artifacts).as_deref(), Some("Firefox.app"));
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn first_app_filename_handles_object_target_form() {
         let artifacts = Some(json!([
@@ -459,6 +496,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn first_app_filename_falls_back_to_source_basename() {
         let artifacts = Some(json!([
@@ -467,6 +505,7 @@ mod tests {
         assert_eq!(first_app_filename(&artifacts).as_deref(), Some("Some.app"));
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn first_app_filename_skips_non_app_artifacts() {
         let artifacts = Some(json!([
@@ -477,6 +516,7 @@ mod tests {
         assert_eq!(first_app_filename(&artifacts).as_deref(), Some("Real.app"));
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn first_app_filename_returns_none_for_no_artifacts() {
         assert_eq!(first_app_filename(&None), None);
@@ -489,6 +529,7 @@ mod tests {
 
     // ---------- resolve_app_bundle ----------
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn resolve_app_bundle_rejects_non_app_filenames() {
         assert_eq!(resolve_app_bundle("Firefox"), None);
@@ -496,6 +537,7 @@ mod tests {
         assert_eq!(resolve_app_bundle(""), None);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn resolve_app_bundle_rejects_path_traversal() {
         assert_eq!(resolve_app_bundle("../etc/passwd.app"), None);
@@ -503,6 +545,7 @@ mod tests {
         assert_eq!(resolve_app_bundle("sub/dir/Foo.app"), None);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn resolve_app_bundle_returns_none_when_neither_path_exists() {
         // This filename is overwhelmingly unlikely to be installed.
@@ -564,6 +607,7 @@ mod tests {
 
     // ---------- M5: safe_join_in_resources ----------
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn safe_join_accepts_plain_filename_in_resources() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -576,6 +620,7 @@ mod tests {
         assert!(resolved.ends_with("AppIcon.icns"));
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn safe_join_rejects_dotdot_traversal() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -590,6 +635,7 @@ mod tests {
         assert!(safe_join_in_resources(&resources, "../../../../etc/passwd.icns").is_none());
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn safe_join_rejects_slash_separated_subpath() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -602,6 +648,7 @@ mod tests {
         assert!(safe_join_in_resources(&resources, "sub/x.icns").is_none());
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn safe_join_rejects_symlink_pointing_outside_resources() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -620,6 +667,7 @@ mod tests {
         assert!(r.is_none(), "symlink escape should be rejected, got {:?}", r);
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn safe_join_returns_none_for_nonexistent_target() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/src-tauri/src/commands/catalog.rs
+++ b/src-tauri/src/commands/catalog.rs
@@ -252,6 +252,14 @@ pub async fn catalog_formulae_summary(
 pub async fn catalog_casks_summary(
     state: State<'_, AppState>,
 ) -> Result<Vec<CatalogEntrySummary>, BrewError> {
+    // Casks are macOS-only — Homebrew on Linux has no cask support, and the
+    // bundled catalog is built on macOS. Returning an empty summary here keeps
+    // every downstream surface (Discover tiles, catalog search, category
+    // counts) honestly cask-free on Linux instead of offering installs that
+    // can only fail with "macOS is required for this software."
+    if cfg!(not(target_os = "macos")) {
+        return Ok(Vec::new());
+    }
     let catalog = read_active_catalog(&state).await;
     let mut out: Vec<CatalogEntrySummary> = catalog
         .casks

--- a/src-tauri/src/commands/disk_usage.rs
+++ b/src-tauri/src/commands/disk_usage.rs
@@ -223,9 +223,25 @@ pub async fn open_in_finder(path: String, state: State<'_, AppState>) -> Result<
         });
     }
 
+    reveal_in_file_manager(&path).await
+}
+
+/// Reveal `path` in the platform file manager. The caller has already
+/// passed the path through the Homebrew-prefix/cache security gate; this
+/// only spawns the reveal.
+///
+/// - macOS: `open -R <path>` selects the item in Finder.
+/// - Linux: there is no portable "reveal and select" verb. `xdg-open
+///   <file>` would *launch* the file in its default app (wrong for a
+///   "show me where this is" action), so we open the containing
+///   directory instead — `xdg-open <parent-dir>` pops the file manager
+///   at the right location. A path with no parent (shouldn't happen for
+///   gated Homebrew paths) falls back to the path itself.
+#[cfg(target_os = "macos")]
+async fn reveal_in_file_manager(path: &str) -> Result<(), BrewError> {
     let status = Command::new("open")
         .arg("-R")
-        .arg(&path)
+        .arg(path)
         .status()
         .await
         .map_err(|e| BrewError::Io {
@@ -234,6 +250,25 @@ pub async fn open_in_finder(path: String, state: State<'_, AppState>) -> Result<
     if !status.success() {
         return Err(BrewError::Internal {
             message: format!("open exited with {:?}", status.code()),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn reveal_in_file_manager(path: &str) -> Result<(), BrewError> {
+    let target = Path::new(path);
+    let dir = target.parent().unwrap_or(target);
+    let status = Command::new("xdg-open")
+        .arg(dir)
+        .status()
+        .await
+        .map_err(|e| BrewError::Io {
+            message: format!("failed to spawn xdg-open: {e}"),
+        })?;
+    if !status.success() {
+        return Err(BrewError::Internal {
+            message: format!("xdg-open exited with {:?}", status.code()),
         });
     }
     Ok(())

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -1,5 +1,17 @@
 //! `brew_doctor` — startup probe for the brew CLI.
+//!
+//! Onboarding additions (missing-Homebrew first launch):
+//! - `system_status()` — cheap local snapshot: is brew resolved, where,
+//!   and are the Xcode Command Line Tools present? No network, no gates.
+//! - `brew_redetect()` — re-runs `resolve_brew_path()` and writes the
+//!   result into `AppState.brew_path` so the app recovers the moment a
+//!   user finishes installing Homebrew, without a relaunch.
+//! - `open_terminal_install()` — opens Terminal.app with the official
+//!   Homebrew install one-liner pre-typed. The script is a FIXED
+//!   constant — zero interpolation — so there is no injection surface.
 
+use serde::Serialize;
+use std::path::PathBuf;
 use tauri::State;
 
 use crate::brew::exec::run_brew_capture;
@@ -50,4 +62,175 @@ pub async fn brew_doctor(state: State<'_, AppState>) -> Result<BrewEnvironment, 
     }
 
     Ok(env)
+}
+
+// ---------- Onboarding: system status + redetect + Terminal launch ----------
+
+/// Snapshot for the missing-Homebrew onboarding gate. Matches
+/// `SystemStatus` in `src/lib/types.ts` (camelCase wire shape).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemStatus {
+    pub brew_found: bool,
+    pub brew_path: Option<String>,
+    pub clt_found: bool,
+}
+
+impl SystemStatus {
+    fn from_brew_path(path: Option<PathBuf>, clt_found: bool) -> Self {
+        Self {
+            brew_found: path.is_some(),
+            brew_path: path.map(|p| p.to_string_lossy().into_owned()),
+            clt_found,
+        }
+    }
+}
+
+/// Probe for the Xcode Command Line Tools: `xcode-select -p` exits 0
+/// when a developer directory is configured. Local check only — no
+/// network, so no paranoid gate. Non-macOS platforms report `true`
+/// (the concept doesn't exist there; brew's own deps differ).
+#[cfg(target_os = "macos")]
+async fn clt_found() -> bool {
+    tokio::process::Command::new("/usr/bin/xcode-select")
+        .arg("-p")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn clt_found() -> bool {
+    true
+}
+
+/// Cheap local status read for the onboarding gate. Consults the cached
+/// `brew_path` (set at startup or by the last `brew_redetect`) — it does
+/// NOT re-scan the filesystem; that's `brew_redetect`'s job.
+#[tauri::command]
+pub async fn system_status(state: State<'_, AppState>) -> Result<SystemStatus, BrewError> {
+    let path = state.brew_path.read().await.clone();
+    Ok(SystemStatus::from_brew_path(path, clt_found().await))
+}
+
+/// Re-run brew detection and persist the result into `AppState.brew_path`
+/// so every `require_brew_path()` caller sees the recovered binary — the
+/// onboarding view polls this until the user's install lands on disk,
+/// and the app comes alive without a relaunch.
+#[tauri::command]
+pub async fn brew_redetect(state: State<'_, AppState>) -> Result<SystemStatus, BrewError> {
+    let path = state.redetect_brew_path().await;
+    Ok(SystemStatus::from_brew_path(path, clt_found().await))
+}
+
+/// AppleScript handed to `osascript` verbatim. FIXED constant — nothing
+/// is ever interpolated into this string, so there is no path for user
+/// or package data to reach the shell. The inner command is the official
+/// Homebrew install one-liner from <https://brew.sh>; Terminal displays
+/// it pre-typed (and running) in a fresh window via `do script`.
+#[cfg(target_os = "macos")]
+const TERMINAL_INSTALL_SCRIPT: &str = r#"tell application "Terminal"
+	activate
+	do script "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+end tell"#;
+
+/// Open Terminal.app with the Homebrew install one-liner pre-typed.
+///
+/// Failure surfaces as a typed `BrewError` (`Io` when osascript can't
+/// spawn, `Internal` on a non-zero exit — e.g. the user denied the
+/// Automation permission prompt) so the frontend can fall back to its
+/// copy-to-clipboard affordance, which is the primary path anyway.
+#[tauri::command]
+pub async fn open_terminal_install() -> Result<(), BrewError> {
+    #[cfg(target_os = "macos")]
+    {
+        let status = tokio::process::Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(TERMINAL_INSTALL_SCRIPT)
+            .status()
+            .await
+            .map_err(|e| BrewError::Io {
+                message: format!("failed to spawn osascript: {e}"),
+            })?;
+        if !status.success() {
+            return Err(BrewError::Internal {
+                message: format!("osascript exited with {:?}", status.code()),
+            });
+        }
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err(BrewError::Internal {
+            message: "open_terminal_install is only available on macOS".into(),
+        })
+    }
+}
+
+// ---------- Tests ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn system_status_serializes_with_camel_case_fields() {
+        let s = SystemStatus {
+            brew_found: true,
+            brew_path: Some("/opt/homebrew/bin/brew".into()),
+            clt_found: false,
+        };
+        let v: Value = serde_json::to_value(&s).unwrap();
+        // Critical: must be camelCase for the frontend's SystemStatus type.
+        assert_eq!(v["brewFound"], true);
+        assert_eq!(v["brewPath"], "/opt/homebrew/bin/brew");
+        assert_eq!(v["cltFound"], false);
+        assert!(v.get("brew_found").is_none(), "must not emit snake_case `brew_found`");
+        assert!(v.get("brew_path").is_none(), "must not emit snake_case `brew_path`");
+        assert!(v.get("clt_found").is_none(), "must not emit snake_case `clt_found`");
+    }
+
+    #[test]
+    fn system_status_serializes_missing_brew_as_null_path() {
+        let s = SystemStatus {
+            brew_found: false,
+            brew_path: None,
+            clt_found: true,
+        };
+        let v: Value = serde_json::to_value(&s).unwrap();
+        assert_eq!(v["brewFound"], false);
+        // Frontend type is `string | null` — None must serialize to null,
+        // not be omitted.
+        assert!(v["brewPath"].is_null());
+        assert_eq!(v["cltFound"], true);
+    }
+
+    #[test]
+    fn from_brew_path_maps_some_and_none_consistently() {
+        let some = SystemStatus::from_brew_path(Some(PathBuf::from("/usr/local/bin/brew")), true);
+        assert!(some.brew_found);
+        assert_eq!(some.brew_path.as_deref(), Some("/usr/local/bin/brew"));
+
+        let none = SystemStatus::from_brew_path(None, true);
+        assert!(!none.brew_found);
+        assert!(none.brew_path.is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_install_script_is_the_fixed_official_one_liner() {
+        // Defense in depth: the script must stay a fixed constant with the
+        // official install URL and no interpolation markers. If someone
+        // ever turns this into a format string, these assertions fire.
+        assert!(TERMINAL_INSTALL_SCRIPT
+            .contains("https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"));
+        assert!(TERMINAL_INSTALL_SCRIPT.starts_with("tell application \"Terminal\""));
+        assert!(TERMINAL_INSTALL_SCRIPT.ends_with("end tell"));
+        assert!(!TERMINAL_INSTALL_SCRIPT.contains("{}"), "no format placeholders allowed");
+        assert!(!TERMINAL_INSTALL_SCRIPT.contains("{0}"), "no format placeholders allowed");
+    }
 }

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -36,7 +36,13 @@ pub async fn brew_search(
         )
         .await
     });
+    // Casks are macOS-only; on Linux `brew search --cask` is a guaranteed
+    // error (Homebrew has no cask support there), so don't spawn it at all —
+    // the cask side of the results is simply empty.
     let c_task = tokio::spawn(async move {
+        if cfg!(not(target_os = "macos")) {
+            return Ok(String::new());
+        }
         run_brew_capture(
             &path2,
             &["search", "--cask", &q2],

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,7 +63,7 @@ pub fn run() {
         )
         .try_init();
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         // Phase 15 — register the updater plugin. The endpoint URL and
@@ -79,9 +79,22 @@ pub fn run() {
         // on exit, then restores it on the next launch. Default StateFlags
         // cover size + position (plus maximized/fullscreen) — exactly what the
         // issue asks for. No frontend wiring: registration is the feature.
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(tauri_plugin_window_state::Builder::default().build());
+
+    // The native menu is macOS-idiomatic: on macOS it populates the
+    // global menu bar at the top of the screen. On Linux/GTK there is
+    // no global menu bar, so Tauri renders it as an in-window GTK
+    // MenuBar strip — redundant (every action is reachable from the
+    // in-app UI) and it clashes with the transparent-window config
+    // (the strip paints see-through). Gate it to macOS so Linux gets a
+    // clean chromeless window. Discovered during the v0.6.0 Linux
+    // bring-up.
+    #[cfg(target_os = "macos")]
+    let builder = builder
         .menu(build_app_menu)
-        .on_menu_event(handle_menu_event)
+        .on_menu_event(handle_menu_event);
+
+    builder
         .setup(|app| {
             state::initialize(app)?;
             // Phase 15 — spawn the auto-check scheduler. The task
@@ -114,6 +127,9 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             app_version,
             brew_doctor,
+            system_status,
+            brew_redetect,
+            open_terminal_install,
             brew_get_analytics,
             brew_set_analytics,
             brew_list,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -275,6 +275,26 @@ impl AppState {
             .ok_or(BrewError::BrewNotFound)
     }
 
+    /// Overwrite the cached brew path. Split out from
+    /// [`Self::redetect_brew_path`] so tests can exercise the RwLock
+    /// update without depending on the host filesystem.
+    pub async fn set_brew_path(&self, path: Option<PathBuf>) {
+        let mut guard = self.brew_path.write().await;
+        *guard = path;
+    }
+
+    /// Re-run brew detection and write the result into `brew_path`.
+    /// Lets the app recover from a missing-brew startup without a
+    /// relaunch — the onboarding gate polls `brew_redetect` until the
+    /// user's Homebrew install lands on disk. Returns the freshly
+    /// detected path so the caller can build its status DTO without a
+    /// second lock acquisition.
+    pub async fn redetect_brew_path(&self) -> Option<PathBuf> {
+        let detected = resolve_brew_path();
+        self.set_brew_path(detected.clone()).await;
+        detected
+    }
+
     /// Consult paranoid mode + settings load state. Returns `Ok(())` if
     /// the outbound call is allowed, or `BrewError::ParanoidModeBlocked`
     /// otherwise. **Every outbound command must call this as its first
@@ -696,5 +716,36 @@ mod tests {
             }
             other => panic!("expected ParanoidModeBlocked from corrupt, got {other:?}"),
         }
+    }
+
+    // ---------- onboarding: set_brew_path / redetect_brew_path ----------
+
+    #[tokio::test]
+    async fn set_brew_path_updates_the_rwlock() {
+        let state = AppState::build().expect("AppState::build");
+        // Simulate a brew-less startup regardless of what build() found.
+        state.set_brew_path(None).await;
+        match state.require_brew_path().await {
+            Err(BrewError::BrewNotFound) => {}
+            other => panic!("expected BrewNotFound after set_brew_path(None), got {other:?}"),
+        }
+        // Setter round-trips an arbitrary path verbatim.
+        let p = PathBuf::from("/tmp/fake-brew-for-test");
+        state.set_brew_path(Some(p.clone())).await;
+        assert_eq!(state.require_brew_path().await.expect("path set"), p);
+    }
+
+    #[tokio::test]
+    async fn redetect_brew_path_writes_resolution_into_state() {
+        // `resolve_brew_path` is filesystem-bound, so we assert agreement
+        // rather than a fixed value: after forcing None, redetect must
+        // leave the RwLock holding exactly what the resolver returns
+        // (Some on a dev host with brew, None on a brew-less CI host).
+        let state = AppState::build().expect("AppState::build");
+        state.set_brew_path(None).await;
+        let detected = state.redetect_brew_path().await;
+        let cached = state.brew_path.read().await.clone();
+        assert_eq!(cached, detected, "redetect must write its result into brew_path");
+        assert_eq!(detected, resolve_brew_path());
     }
 }

--- a/src-tauri/src/vulns/cache.rs
+++ b/src-tauri/src/vulns/cache.rs
@@ -111,6 +111,10 @@ impl VulnKey {
     /// Parse the on-disk key form. Returns `None` for malformed input;
     /// callers should drop unparseable entries (probably from a future
     /// schema or a corrupted file) rather than fail-open.
+    ///
+    /// Currently uncalled (cache loading treats stored keys as opaque
+    /// strings); kept as the documented inverse of `to_storage_key`.
+    #[allow(dead_code)]
     pub fn parse(s: &str) -> Option<Self> {
         // Split on the first two `:` so names with `@` (openssl@3) or
         // versions with `:` (rare but possible for epoch-style versions)
@@ -221,6 +225,11 @@ impl VulnsCache {
     }
 
     /// Lookup a record. Returns `None` if absent OR stale.
+    ///
+    /// No production caller since the scan flow moved to whole-set
+    /// fingerprint skips; exercised by the tests below and kept as the
+    /// per-key TTL counterpart of the stale-tolerant lookup.
+    #[allow(dead_code)]
     pub fn get_fresh(&self, key: &VulnKey) -> Option<&ScanRecord> {
         let rec = self.file.entries.get(&key.to_storage_key())?;
         if record_is_fresh(rec) {
@@ -307,7 +316,9 @@ pub fn cache_path(app_data_dir: &Path) -> PathBuf {
 }
 
 /// Per-record freshness check. Pulled out so the predicate is easy to
-/// stub in tests if we ever need a synthetic clock.
+/// stub in tests if we ever need a synthetic clock. (Only caller is
+/// `get_fresh`, itself currently test-only — see there.)
+#[allow(dead_code)]
 fn record_is_fresh(rec: &ScanRecord) -> bool {
     elapsed_since(rec.scanned_at) < VULNS_CACHE_TTL
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,6 +51,18 @@
       "signingIdentity": "Developer ID Application: Michael Sitarzewski (7JQGQ7CRH8)",
       "hardenedRuntime": true,
       "minimumSystemVersion": "13.0"
+    },
+    "linux": {
+      "deb": {
+        "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0",
+          "libayatana-appindicator3-1"
+        ]
+      },
+      "appimage": {
+        "bundleMediaFramework": false
+      }
     }
   }
 }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "brew-browser",
+        "width": 1100,
+        "height": 720,
+        "minWidth": 800,
+        "minHeight": 500,
+        "transparent": false
+      }
+    ]
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,6 +47,7 @@ import type {
   SearchResults,
   Service,
   Settings,
+  SystemStatus,
   TrendingHistoryIndex,
   TrendingHistorySeries,
   TrendingReport,
@@ -61,6 +62,35 @@ import type {
 
 export function brewDoctor(): Promise<BrewEnvironment> {
   return invoke<BrewEnvironment>("brew_doctor");
+}
+
+/**
+ * Cheap local probe for the onboarding gate: is brew resolved (and where),
+ * and are the Xcode Command Line Tools present? Reads the backend's cached
+ * brew path — no filesystem re-scan, no network, no gates.
+ */
+export function systemStatus(): Promise<SystemStatus> {
+  return invoke<SystemStatus>("system_status");
+}
+
+/**
+ * Re-run brew detection and write the result into backend state so every
+ * brew-dependent command sees the recovered binary — the onboarding view
+ * polls this until the user's Homebrew install lands, then the app comes
+ * alive without a relaunch.
+ */
+export function brewRedetect(): Promise<SystemStatus> {
+  return invoke<SystemStatus>("brew_redetect");
+}
+
+/**
+ * Open Terminal.app with the official Homebrew install one-liner pre-typed
+ * (a fixed constant on the backend — zero interpolation). Throws a typed
+ * `BrewErrorPayload` when osascript fails (e.g. Automation permission
+ * denied); callers fall back to the copy-to-clipboard affordance.
+ */
+export function openTerminalInstall(): Promise<void> {
+  return invoke<void>("open_terminal_install");
 }
 
 /**

--- a/src/lib/components/AboutModal.svelte
+++ b/src/lib/components/AboutModal.svelte
@@ -9,6 +9,7 @@
   import { env } from "$lib/stores/env.svelte";
   import { appVersion } from "$lib/api";
   import { safeOpenUrl } from "$lib/util/url";
+  import { isLinux } from "$lib/util/platform";
   import { SPONSOR_URL } from "$lib/util/donate";
 
   const REPO_URL = "https://github.com/msitarzewski/brew-browser";
@@ -92,10 +93,12 @@
           Technical Writer, and friends), powered by <strong>Claude Code</strong> in
           the terminal, running <strong>Opus 4.7 [1m]</strong>.
         </p>
+        <!-- Linux: casks don't exist there, so the credit names formula
+             maintainers only. -->
         <p class="thanks">
           Thanks also to the Homebrew project for the package data, every
-          formula and cask maintainer for their work, and Tauri for the
-          native shell.
+          {isLinux ? "formula" : "formula and cask"} maintainer for their work,
+          and Tauri for the native shell.
         </p>
       </section>
 

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -34,6 +34,7 @@
   import { resolveCategoryIcon } from "$lib/util/categoryIcon";
   import { brewErrorMessage, isBrewError, type DiskUsageReport } from "$lib/types";
   import { reportableToastError } from "$lib/util/reportIssue";
+  import { isLinux, isMac } from "$lib/util/platform";
 
   let disk = $state<DiskUsageReport | null>(null);
   let diskLoading = $state(false);
@@ -59,7 +60,7 @@
     try {
       await openInFinder(path);
     } catch (e) {
-      reportableToastError("Couldn't reveal in Finder", e);
+      reportableToastError(isMac ? "Couldn't reveal in Finder" : "Couldn't open in file manager", e);
     }
   }
 
@@ -681,8 +682,12 @@
 
       <!-- Composition + Top categories — paired side-by-side on wide panes
            (matches native's >980px breakpoint); stacked full-width below,
-           where Composition reverts to a horizontal bar. -->
-      <div class="dash-pair" class:paired={categories.visible && categorySegments.length > 0}>
+           where Composition reverts to a horizontal bar.
+           Linux: casks don't exist, so a formulae-vs-casks split is a
+           single-kind chart — the whole Composition card is hidden (and
+           the pair never pairs; categories takes the full width). -->
+      <div class="dash-pair" class:paired={!isLinux && categories.visible && categorySegments.length > 0}>
+        {#if !isLinux}
         <section class="card comp-card">
           <div class="card-head">
             <h2>Composition</h2>
@@ -738,6 +743,7 @@
             </div>
           </div>
         </section>
+        {/if}
 
         <!-- Top categories — donut. Phase 13: hidden when the AI Features
              toggle is off (categories are LLM-generated). -->
@@ -881,7 +887,9 @@
           </div>
         {:else if disk}
           <ul class="storage-list">
-            {#each disk.entries as e (e.path)}
+            <!-- Linux: no casks → the Caskroom row (always "not present"
+                 there) is dropped. macOS renders every entry as-is. -->
+            {#each disk.entries.filter((e) => !isLinux || e.label !== "Casks (Caskroom)") as e (e.path)}
               <li>
                 <div class="storage-row">
                   <span class="s-label">{e.label}</span>
@@ -899,8 +907,8 @@
                     class="s-open"
                     onclick={() => reveal(e.path)}
                     disabled={!e.exists}
-                    title={e.exists ? `Reveal ${e.path} in Finder` : "Path doesn't exist"}
-                    aria-label={`Reveal ${e.label} in Finder`}
+                    title={e.exists ? (isMac ? `Reveal ${e.path} in Finder` : `Show ${e.path} in file manager`) : "Path doesn't exist"}
+                    aria-label={isMac ? `Reveal ${e.label} in Finder` : `Show ${e.label} in file manager`}
                   >
                     <FolderOpen size={14} />
                   </button>

--- a/src/lib/components/Discover.svelte
+++ b/src/lib/components/Discover.svelte
@@ -18,6 +18,7 @@
   import { enrichment } from "$lib/stores/enrichment.svelte";
   import { toast } from "$lib/stores/toast.svelte";
   import { resolveCategoryIcon } from "$lib/util/categoryIcon";
+  import { isLinux } from "$lib/util/platform";
   import type { PackageKind, SearchHit } from "$lib/types";
 
   // Lazy-load categories + catalog summary on mount. The stores guard
@@ -111,6 +112,10 @@
   /**
    * Browse-mode list (no search query): union of all packages whose categories
    * intersect the selected chips. Sorted alphabetically for stable scan order.
+   *
+   * Linux: the bundled categories.json still carries cask tokens (it's
+   * platform-agnostic data), but casks don't exist on Linux — skip them so
+   * browse mode never lists uninstallable cask-only apps.
    */
   let browseItems = $derived.by<Array<{ name: string; kind: PackageKind }>>(() => {
     if (!discover.hasFilter || !categories.data) return [];
@@ -118,6 +123,7 @@
     const out: Array<{ name: string; kind: PackageKind }> = [];
     for (const slug of discover.selectedCategories) {
       for (const pkg of categories.tokensInCategory(slug)) {
+        if (isLinux && pkg.kind === "cask") continue;
         const key = `${pkg.kind}:${pkg.name}`;
         if (!set.has(key)) {
           set.add(key);
@@ -327,9 +333,11 @@
       <!-- Default: category tile grid. Phase 13: hidden when AI toggle
            off. The empty state below covers the toggled-off case. -->
       <div class="cat-intro">
+        <!-- Linux: the bundled categories.json includes cask tokens, but
+             casks don't exist there — count formulae only. -->
         <p class="text-muted">
           Browse {fmt(
-            Object.keys(categories.data?.casks ?? {}).length +
+            (isLinux ? 0 : Object.keys(categories.data?.casks ?? {}).length) +
               Object.keys(categories.data?.formulae ?? {}).length,
           )} packages by category, or type a query above to search.
         </p>

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -18,6 +18,7 @@
   import { enrichment } from "$lib/stores/enrichment.svelte";
   import { vulnerabilities } from "$lib/stores/vulnerabilities.svelte";
   import { resolveCategoryIcon } from "$lib/util/categoryIcon";
+  import { isLinux } from "$lib/util/platform";
   import type { Package } from "$lib/types";
 
   type SortKey = "name" | "version" | "kind" | "outdated";
@@ -31,11 +32,13 @@
   // when the feature is enabled. Adding it unconditionally would show a
   // dead filter pill (always 0) to users who never opted in, which is
   // worse than not surfacing it at all.
-  let libraryFilters = $derived<LibraryFilter[]>(
-    vulnerabilities.enabled
+  // Linux: casks don't exist there, so the Casks pill (always 0) is dropped.
+  let libraryFilters = $derived.by<LibraryFilter[]>(() => {
+    const base: LibraryFilter[] = vulnerabilities.enabled
       ? ["all", "formulae", "casks", "outdated", "vulnerable"]
-      : ["all", "formulae", "casks", "outdated"],
-  );
+      : ["all", "formulae", "casks", "outdated"];
+    return base.filter((f) => !(isLinux && f === "casks"));
+  });
 
   // Library shares the Discover store's chip selection so jumping back-and-forth
   // between tabs keeps context. Categories load is idempotent.
@@ -244,12 +247,20 @@
         {/snippet}
       </EmptyState>
     {:else}
-      <div class="list-header" role="row">
+      <!-- Linux: every installed package is a formula, so the Type column
+           is pure noise — the sortable header gives way to an empty
+           placeholder cell (the rows keep a slim 5th cell for the vuln
+           severity dot, see PackageRow's `no-kind` variant). -->
+      <div class="list-header" class:no-kind={isLinux} role="row">
         <span></span>
         <SortableHeader label="Name" sortKey="name" active={sortKey === "name"} dir={sortDir} onSort={changeSort} />
         <span class="header-desc">Description</span>
         <SortableHeader label="Version" sortKey="version" active={sortKey === "version"} dir={sortDir} onSort={changeSort} />
-        <SortableHeader label="Type" sortKey="kind" active={sortKey === "kind"} dir={sortDir} onSort={changeSort} />
+        {#if !isLinux}
+          <SortableHeader label="Type" sortKey="kind" active={sortKey === "kind"} dir={sortDir} onSort={changeSort} />
+        {:else}
+          <span></span>
+        {/if}
         <SortableHeader label="Outdated" sortKey="outdated" active={sortKey === "outdated"} dir={sortDir} onSort={changeSort} />
       </div>
       <div class="list" role="list" aria-label="Installed packages">
@@ -428,6 +439,29 @@
     .list-header > :nth-child(3),
     .list-header > :nth-child(4),
     .list-header > :nth-child(6) { display: none; }
+  }
+
+  /* Linux (`no-kind`): mirrors PackageRow's `no-kind` templates — the
+     TYPE track shrinks from 80px to the 12px vuln-dot slot. The header
+     keeps an empty placeholder in the 5th cell, so the macOS nth-child
+     hide rules above apply unchanged at every breakpoint. */
+  .list-header.no-kind {
+    grid-template-columns: 24px minmax(0, 1fr) minmax(0, 2fr) 120px 12px 120px;
+  }
+  @media (max-width: 1100px) {
+    .list-header.no-kind {
+      grid-template-columns: 24px minmax(0, 1fr) minmax(0, 2fr) 120px 12px;
+    }
+  }
+  @media (max-width: 900px) {
+    .list-header.no-kind {
+      grid-template-columns: 24px minmax(0, 1fr) 120px 12px;
+    }
+  }
+  @media (max-width: 720px) {
+    .list-header.no-kind {
+      grid-template-columns: 24px minmax(0, 1fr) 12px;
+    }
   }
   .list { display: flex; flex-direction: column; }
 </style>

--- a/src/lib/components/OnboardingView.svelte
+++ b/src/lib/components/OnboardingView.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import Terminal from "@lucide/svelte/icons/terminal";
+  import Copy from "@lucide/svelte/icons/copy";
+  import EmptyState from "$lib/components/EmptyState.svelte";
+  import Button from "$lib/components/Button.svelte";
+  import { openTerminalInstall } from "$lib/api";
+  import { env } from "$lib/stores/env.svelte";
+  import { toast } from "$lib/stores/toast.svelte";
+  import { isMac } from "$lib/util/platform";
+
+  /**
+   * Official Homebrew install one-liner from brew.sh — the SAME script
+   * installs Linuxbrew (to /home/linuxbrew/.linuxbrew or ~/.linuxbrew).
+   * Mirrors the fixed TERMINAL_INSTALL_SCRIPT constant in
+   * `src-tauri/src/commands/env.rs` — keep the two in sync if upstream
+   * ever changes the incantation.
+   */
+  const INSTALL_COMMAND =
+    '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"';
+
+  let openingTerminal = $state(false);
+
+  // Same clipboard pattern as DeviceFlowModal.copyCode().
+  function copyCommand() {
+    void navigator.clipboard.writeText(INSTALL_COMMAND).then(
+      () => toast.success("Install command copied to clipboard"),
+      () => toast.error("Couldn't copy command"),
+    );
+  }
+
+  async function openTerminal() {
+    openingTerminal = true;
+    try {
+      await openTerminalInstall();
+    } catch {
+      // osascript failed (e.g. Automation permission denied) — fall back
+      // to the clipboard, which is the primary affordance anyway.
+      void navigator.clipboard.writeText(INSTALL_COMMAND).then(
+        () =>
+          toast.info(
+            "Couldn't open Terminal",
+            "The install command was copied instead — paste it into any terminal.",
+          ),
+        () => toast.error("Couldn't open Terminal or copy the command"),
+      );
+    } finally {
+      openingTerminal = false;
+    }
+  }
+</script>
+
+<div class="onboarding" role="region" aria-label="Homebrew setup">
+  <EmptyState
+    title="Let's get Homebrew set up"
+    body={isMac
+      ? "brew-browser is a friendly face for Homebrew, the package manager for your Mac. Install it once and your library appears here automatically — no relaunch needed."
+      : "brew-browser is a friendly face for Homebrew, which runs on Linux too. Install it once and your library appears here automatically — no relaunch needed."}
+  >
+    {#snippet icon()}<Terminal size={48} />{/snippet}
+    {#snippet cta()}
+      <div class="steps">
+        <ol>
+          {#if env.status?.cltFound === false}
+            <li>
+              Install the Xcode Command Line Tools first: run
+              <code class="inline">xcode-select --install</code> in Terminal and follow the prompts.
+            </li>
+          {/if}
+          {#if !isMac}
+            <li>
+              Install Homebrew's build dependencies first — on Debian/Ubuntu:
+              <code class="inline">sudo apt-get install build-essential procps curl file git</code>
+              (other distros: see the "Homebrew on Linux" page at docs.brew.sh).
+            </li>
+          {/if}
+          <li>
+            Install Homebrew by running this in {isMac ? "Terminal" : "your terminal"}:
+            <div class="cmd"><code>{INSTALL_COMMAND}</code></div>
+          </li>
+        </ol>
+        <div class="actions">
+          <Button variant="primary" onclick={copyCommand} ariaLabel="Copy install command">
+            {#snippet icon()}<Copy size={14} />{/snippet}
+            Copy command
+          </Button>
+          {#if isMac}
+            <!-- macOS-only: `open_terminal_install` drives Terminal.app via
+                 osascript and is gated server-side too. On Linux there is no
+                 single terminal emulator to target — the copy button is the
+                 whole affordance. -->
+            <Button
+              variant="secondary"
+              loading={openingTerminal}
+              onclick={openTerminal}
+              title="Opens Terminal with the install command pre-typed"
+            >
+              Open Terminal
+            </Button>
+          {/if}
+        </div>
+        <p class="waiting" role="status">
+          <span class="dot" aria-hidden="true"></span>
+          Waiting for Homebrew… the app refreshes itself the moment the install finishes.
+        </p>
+      </div>
+    {/snippet}
+  </EmptyState>
+</div>
+
+<style>
+  /* Fill the main pane so EmptyState's min-height:100% centering works. */
+  .onboarding {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    background: var(--color-surface);
+  }
+  .steps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    text-align: left;
+    min-width: 0;
+  }
+  ol {
+    margin: 0;
+    padding-left: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  li {
+    font-size: var(--text-body-sm);
+    color: var(--color-text-secondary);
+    line-height: var(--lh-normal);
+  }
+  code.inline {
+    font-family: var(--font-mono);
+    font-size: var(--text-body-sm);
+    color: var(--color-text-primary);
+    background: var(--color-surface-sunken);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0 var(--space-1);
+  }
+  .cmd {
+    margin-top: var(--space-2);
+    padding: var(--space-3);
+    background: var(--color-surface-sunken);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+  }
+  .cmd code {
+    font-family: var(--font-mono);
+    font-size: var(--text-body-sm);
+    color: var(--color-text-primary);
+    white-space: pre-wrap;
+    word-break: break-all;
+    user-select: all;
+  }
+  .actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: center;
+  }
+  .waiting {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    font-size: var(--text-body-sm);
+    color: var(--color-text-muted);
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-text-muted);
+    animation: pulse 1.6s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 0.3; }
+    50%      { opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dot { animation: none; }
+  }
+</style>

--- a/src/lib/components/PackageDetail.svelte
+++ b/src/lib/components/PackageDetail.svelte
@@ -45,6 +45,7 @@
   import ShieldAlert from "@lucide/svelte/icons/shield-alert";
   import Shield from "@lucide/svelte/icons/shield";
   import { brewInfo, brewInstall, brewUninstall, brewUpgrade, appVersion } from "$lib/api";
+  import { isLinux } from "$lib/util/platform";
   import { safeOpenUrl } from "$lib/util/url";
   import { bareToken } from "$lib/util/token";
   import { reportableToastError } from "$lib/util/reportIssue";
@@ -287,6 +288,10 @@
   let pkg = $derived<PackageDetail["package"] | undefined>(detail?.package);
   let isInstalled = $derived(!!pkg?.installedVersion);
   let isOutdated = $derived(!!pkg?.outdated);
+  // Casks are macOS-only; the backend already keeps them out of Discover and
+  // search on Linux, but detail can still surface one (snapshots, deep links)
+  // — never offer an Install that can only fail with "macOS is required".
+  let caskOnLinux = $derived(isLinux && ui.selectedPackage?.kind === "cask");
 
   /** Categories assigned to this package (from `categories.json`). */
   let pkgCategories = $derived.by<string[]>(() => {
@@ -1522,6 +1527,8 @@
           {#snippet icon()}<Trash2 size={16} />{/snippet}
           Uninstall
         </Button>
+      {:else if pkg && caskOnLinux}
+        <p class="cask-unavailable">Casks require macOS — this package can't be installed on Linux.</p>
       {:else if pkg}
         <Button variant="primary" onclick={handleInstallClick}>
           {#snippet icon()}<Download size={16} />{/snippet}
@@ -1820,6 +1827,13 @@
     padding: var(--space-4);
     border-top: 1px solid var(--color-border);
     justify-content: flex-end;
+  }
+
+  .cask-unavailable {
+    margin: 0;
+    font-size: var(--text-body-sm);
+    color: var(--color-text-secondary);
+    align-self: center;
   }
 
   .error { padding: var(--space-4); display: flex; flex-direction: column; gap: var(--space-3); }

--- a/src/lib/components/PackageRow.svelte
+++ b/src/lib/components/PackageRow.svelte
@@ -5,6 +5,7 @@
   import { enrichment } from "$lib/stores/enrichment.svelte";
   import { settings } from "$lib/stores/settings.svelte";
   import { vulnerabilities } from "$lib/stores/vulnerabilities.svelte";
+  import { isLinux } from "$lib/util/platform";
   import type { Package, Severity } from "$lib/types";
 
   interface Props {
@@ -83,6 +84,7 @@
 
 <button
   class="row"
+  class:no-kind={isLinux}
   class:selected
   aria-current={selected ? "true" : undefined}
   onclick={() => onSelect?.(pkg)}
@@ -96,8 +98,14 @@
   </span>
   <span class="desc truncate text-muted" title={descOf() ?? ""}>{descOf() ?? ""}</span>
   <span class="version truncate">{pkg.installedVersion ?? pkg.stableVersion ?? "—"}</span>
+  <!-- Linux: every installed package is a formula, so the type pill is
+       pure noise and isn't rendered (`no-kind` collapses the column).
+       The cell itself stays — it also hosts the vulnerability severity
+       dot, which is fully meaningful on Linux. -->
   <span class="kind">
-    <Pill tone={pkg.kind === "formula" ? "formula" : "cask"}>{pkg.kind}</Pill>
+    {#if !isLinux}
+      <Pill tone={pkg.kind === "formula" ? "formula" : "cask"}>{pkg.kind}</Pill>
+    {/if}
     {#if vulnMaxSeverity !== null}
       <!-- Severity dot — colour wins by max severity. Hover tooltip
            exposes the count and highest band; click bubbles up to the
@@ -168,6 +176,30 @@
     .row > :nth-child(3),
     .row > :nth-child(4),
     .row > :nth-child(6) { display: none; }
+  }
+
+  /* Linux (`no-kind`): the type pill isn't rendered, so the TYPE track
+     shrinks from 80px to a fixed 12px slot that fits just the 9px vuln
+     severity dot (fixed, not auto, so columns stay aligned across rows
+     with and without findings). The cell count is unchanged — the macOS
+     nth-child hide rules above apply as-is at every breakpoint. */
+  .row.no-kind {
+    grid-template-columns: 24px minmax(0, 1fr) minmax(0, 2fr) 120px 12px 120px;
+  }
+  @media (max-width: 1100px) {
+    .row.no-kind {
+      grid-template-columns: 24px minmax(0, 1fr) minmax(0, 2fr) 120px 12px;
+    }
+  }
+  @media (max-width: 900px) {
+    .row.no-kind {
+      grid-template-columns: 24px minmax(0, 1fr) 120px 12px;
+    }
+  }
+  @media (max-width: 720px) {
+    .row.no-kind {
+      grid-template-columns: 24px minmax(0, 1fr) 12px;
+    }
   }
   .row:hover { background: var(--color-surface-sunken); }
   .row.selected {

--- a/src/lib/components/SettingsSectionGitHub.svelte
+++ b/src/lib/components/SettingsSectionGitHub.svelte
@@ -28,6 +28,7 @@
 
   import { settings } from "$lib/stores/settings.svelte";
   import { github } from "$lib/stores/github.svelte";
+  import { keyringName } from "$lib/util/platform";
 
   onMount(() => {
     void github.loadStatus();
@@ -117,7 +118,7 @@
       <strong>What sign-in is used for</strong>
     </div>
     <p class="privacy-body">
-      brew-browser stores your token in the macOS Keychain. The token is
+      brew-browser stores your token in the {keyringName}. The token is
       <strong>never</strong> sent over IPC to the renderer,
       <strong>never</strong> written to disk, and <strong>never</strong>
       logged. Only the derived <code>{`{ signedIn, username, scopes }`}</code>

--- a/src/lib/components/SettingsSectionNetwork.svelte
+++ b/src/lib/components/SettingsSectionNetwork.svelte
@@ -26,6 +26,7 @@
   import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 
   import { settings } from "$lib/stores/settings.svelte";
+  import { isLinux } from "$lib/util/platform";
   import SettingsSectionUpdates from "$lib/components/SettingsSectionUpdates.svelte";
   import SettingsSectionTrendingHistory from "$lib/components/SettingsSectionTrendingHistory.svelte";
   import SettingsSectionLiveEnrichment from "$lib/components/SettingsSectionLiveEnrichment.svelte";
@@ -37,10 +38,11 @@
 
   /** Tooltip + accessible-description copy for the Offline Mode toggle
       (Phase 15 plan §11 item 13). Centralised in one constant so the
-      `title` attribute and the on-screen hint stay in sync. */
+      `title` attribute and the on-screen hint stay in sync. Linux: casks
+      (and therefore cask icon probes) don't exist — the phrase is dropped. */
   const OFFLINE_MODE_DESCRIPTION =
     "Blocks every outbound network call: catalog refresh, Trending fetch, " +
-    "GitHub stats, GitHub sign-in, cask icon homepage probes, update checks. " +
+    `GitHub stats, GitHub sign-in, ${isLinux ? "" : "cask icon homepage probes, "}update checks. ` +
     "All UI that depends on the network shows a 'disabled by Offline Mode' " +
     "notice. brew itself still runs normally — its network access is the " +
     "user's call at the terminal.";
@@ -110,21 +112,28 @@
         allowed: !paranoid,
       },
       {
-        label: "formulae.brew.sh/api/{formula,cask}.json",
+        // Linux: the backend only fetches formula.json (no casks there).
+        label: isLinux
+          ? "formulae.brew.sh/api/formula.json"
+          : "formulae.brew.sh/api/{formula,cask}.json",
         desc: `Catalog refresh — ${s.catalogAutoRefresh === "off"
           ? "manual only"
           : `scheduled (${s.catalogAutoRefresh})`}.`,
         allowed: !paranoid,
       },
-      {
-        label: "Cask homepage probes",
-        desc: `Uninstalled-cask icon cascade — ${
-          s.caskIconMode === "off" ? "disabled" :
-          s.caskIconMode === "installed-only" ? "installed apps only" :
-          "all casks with a homepage"
-        }.`,
-        allowed: !paranoid && s.caskIconMode !== "off",
-      },
+      // Linux: no casks → no cask icon cascade; the entry would describe
+      // a path that can never be exercised, so it's omitted entirely.
+      ...(isLinux
+        ? []
+        : [{
+            label: "Cask homepage probes",
+            desc: `Uninstalled-cask icon cascade — ${
+              s.caskIconMode === "off" ? "disabled" :
+              s.caskIconMode === "installed-only" ? "installed apps only" :
+              "all casks with a homepage"
+            }.`,
+            allowed: !paranoid && s.caskIconMode !== "off",
+          }]),
       {
         label: "brew-browser.zerologic.com/trending-history",
         desc: s.enhancedTrendingEnabled
@@ -139,7 +148,9 @@
       },
       {
         label: "Default browser",
-        desc: "Opening external links hands off to macOS open(1). Not a network call from us.",
+        // tauri-plugin-opener delegates to the `open` crate: open(1) on
+        // macOS, xdg-open (first in its fallback chain) on Linux.
+        desc: `Opening external links hands off to ${isLinux ? "xdg-open" : "macOS open(1)"}. Not a network call from us.`,
         allowed: true,
       },
     ];
@@ -195,8 +206,12 @@
       {#if settings.data.paranoidMode}
         <div class="callout warn" role="status">
           <AlertTriangle size={16} />
-          <span>Offline Mode is on — Trending, Catalog refresh, and
-            Cask icon probes are blocked.</span>
+          {#if isLinux}
+            <span>Offline Mode is on — Trending and Catalog refresh are blocked.</span>
+          {:else}
+            <span>Offline Mode is on — Trending, Catalog refresh, and
+              Cask icon probes are blocked.</span>
+          {/if}
         </div>
       {/if}
     </div>
@@ -245,7 +260,9 @@
         {CATALOG_STALE_MIN}–{CATALOG_STALE_MAX}.</p>
     </div>
 
-    <!-- Cask icon mode -->
+    <!-- Cask icon mode. Linux: casks don't exist there, so the whole
+         control (and the icon cascade it configures) is hidden. -->
+    {#if !isLinux}
     <div class="field">
       <span class="field-label">Cask icon fetching</span>
       <div class="radio-row" role="radiogroup" aria-label="Cask icon fetching">
@@ -267,6 +284,7 @@
         skips the homepage cascade for uninstalled casks. Off disables icon
         extraction entirely.</p>
     </div>
+    {/if}
 
     <!-- Trending TTL -->
     <div class="field">

--- a/src/lib/components/Snapshots.svelte
+++ b/src/lib/components/Snapshots.svelte
@@ -19,6 +19,7 @@
   import { toast } from "$lib/stores/toast.svelte";
   import { brewfileDump, brewfileInstall, brewfileDelete, brewfileExport, brewfileImport } from "$lib/api";
   import type { BrewfileSummary } from "$lib/types";
+  import { isLinux } from "$lib/util/platform";
   import { reportableToastError } from "$lib/util/reportIssue";
 
   let newLabel = $state("");
@@ -162,10 +163,15 @@
     {:else if brewfiles.list.length === 0}
       <!-- Inline CTAs intentionally omitted: the same actions live in
            the panel-head's top-right (Import… + New Snapshot), so the
-           empty state stays purely informational. -->
+           empty state stays purely informational. The storage path mirrors
+           the backend's `resolve_brewfiles_dir` (dirs::data_dir() +
+           brew-browser/brewfiles/): ~/Library/Application Support on macOS,
+           XDG data home (~/.local/share by default) on Linux. -->
       <EmptyState
         title="No snapshots yet."
-        body="Save your current setup so you can restore it on another Mac. Snapshots live in ~/Library/Application Support/brew-browser/brewfiles/ — findable outside the app too."
+        body={isLinux
+          ? "Save your current setup so you can restore it on another machine. Snapshots live in ~/.local/share/brew-browser/brewfiles/ — findable outside the app too."
+          : "Save your current setup so you can restore it on another Mac. Snapshots live in ~/Library/Application Support/brew-browser/brewfiles/ — findable outside the app too."}
       >
         {#snippet icon()}<Archive size={48} />{/snippet}
       </EmptyState>
@@ -176,7 +182,10 @@
             <header class="card-head">
               <div>
                 <h2>{b.label}</h2>
-                <p class="meta">{formatDate(b.createdAt)} · {b.counts.formulae} formulae · {b.counts.casks} casks{#if b.counts.masApps > 0} · {b.counts.masApps} MAS apps{/if}</p>
+                <!-- Brewfiles legitimately carry cask lines (a snapshot may
+                     come from a Mac) — real cask counts always show. Only
+                     the decorative "0 casks" is suppressed on Linux. -->
+                <p class="meta">{formatDate(b.createdAt)} · {b.counts.formulae} formulae{#if !isLinux || b.counts.casks > 0} · {b.counts.casks} casks{/if}{#if b.counts.masApps > 0} · {b.counts.masApps} MAS apps{/if}</p>
               </div>
               <div class="actions">
                 <Button size="sm" variant="primary" onclick={() => (toRestore = b)}>

--- a/src/lib/components/Trending.svelte
+++ b/src/lib/components/Trending.svelte
@@ -19,6 +19,7 @@
   import { packages } from "$lib/stores/packages.svelte";
   import { enrichment } from "$lib/stores/enrichment.svelte";
   import { catalog } from "$lib/stores/catalog.svelte";
+  import { isLinux } from "$lib/util/platform";
   import type { PackageKind, TrendingEntry, TrendingWindow } from "$lib/types";
 
   onMount(() => {
@@ -160,12 +161,17 @@
         {#snippet icon()}<TrendingUp size={48} />{/snippet}
       </EmptyState>
     {:else if trending.report}
-      <div class="list-header" role="row">
+      <!-- Linux: every trending entry is kind=formula (the backend filters
+           casks out), so the Type column is pure noise — dropped via the
+           `no-kind` grid variant. macOS keeps the full 8-column layout. -->
+      <div class="list-header" class:no-kind={isLinux} role="row">
         <SortableHeader label="#" sortKey="rank" active={sortKey === "rank"} dir={sortDir} onSort={changeSort} />
         <SortableHeader label="Name" sortKey="name" active={sortKey === "name"} dir={sortDir} onSort={changeSort} />
         <span class="header-desc">Description</span>
         <span class="header-version">Version</span>
-        <SortableHeader label="Type" sortKey="kind" active={sortKey === "kind"} dir={sortDir} onSort={changeSort} />
+        {#if !isLinux}
+          <SortableHeader label="Type" sortKey="kind" active={sortKey === "kind"} dir={sortDir} onSort={changeSort} />
+        {/if}
         <SortableHeader label="Velocity" sortKey="velocity" active={sortKey === "velocity"} dir={sortDir} onSort={changeSort} align="right" />
         <SortableHeader label="Installs" sortKey="installs" active={sortKey === "installs"} dir={sortDir} onSort={changeSort} align="right" />
         <span></span>
@@ -180,6 +186,7 @@
           <li>
             <button
               class="row"
+              class:no-kind={isLinux}
               class:selected={isSelected}
               aria-current={isSelected ? "true" : undefined}
               onclick={() => openEntry(e.name, e.kind)}
@@ -196,7 +203,9 @@
               </span>
               <span class="desc truncate text-muted">{enrichment.summaryOf(e.name) ?? catalog.descOf(e.name, e.kind) ?? ""}</span>
               <span class="version truncate text-muted">{catalog.versionOf(e.name, e.kind) ?? ""}</span>
-              <span class="kind"><Pill tone={e.kind === "formula" ? "formula" : "cask"}>{e.kind}</Pill></span>
+              {#if !isLinux}
+                <span class="kind"><Pill tone={e.kind === "formula" ? "formula" : "cask"}>{e.kind}</Pill></span>
+              {/if}
               <span class="velocity mono" class:surge={tier === "surge"} class:cool={tier === "cool"}>
                 {#if tier === "surge"}
                   <Flame size={12} aria-hidden="true" />
@@ -296,6 +305,43 @@
     .row > :nth-child(4),
     .row > :nth-child(5),
     .row > :nth-child(8) { display: none; }
+  }
+
+  /* Linux (`no-kind`): the TYPE column isn't rendered, leaving 7 cells
+     (# / NAME / DESC / VERSION / VELOCITY / COUNT / TRAIL). Same
+     responsive ladder as macOS with every index past the removed column
+     shifted left by one (Trail is now 7th). The macOS nth-child rules
+     above still hide DESC (3rd) and VERSION (4th) at the right widths. */
+  .list-header.no-kind,
+  .row.no-kind {
+    grid-template-columns: 48px minmax(0, 1fr) minmax(0, 2fr) 100px 90px 120px 100px;
+  }
+  @media (max-width: 1200px) {
+    .list-header.no-kind,
+    .row.no-kind {
+      grid-template-columns: 48px minmax(0, 1fr) minmax(0, 2fr) 100px 90px 120px;
+    }
+    .list-header.no-kind > :nth-child(7),
+    .row.no-kind > :nth-child(7) { display: none; }
+  }
+  @media (max-width: 1000px) {
+    .list-header.no-kind,
+    .row.no-kind {
+      grid-template-columns: 48px minmax(0, 1fr) 100px 90px 120px;
+    }
+  }
+  @media (max-width: 800px) {
+    .list-header.no-kind,
+    .row.no-kind {
+      grid-template-columns: 48px minmax(0, 1fr) 90px 120px;
+    }
+  }
+  @media (max-width: 640px) {
+    /* The macOS rule hides :nth-child(5) (TYPE); without the TYPE column
+       the 5th cell is VELOCITY, which stays visible at this width —
+       restore it (header button and row span are both inline-flex). */
+    .list-header.no-kind > :nth-child(5),
+    .row.no-kind > :nth-child(5) { display: inline-flex; }
   }
 
   /* Sidebar theme-group pattern: sunken background, no border,

--- a/src/lib/stores/categories.svelte.ts
+++ b/src/lib/stores/categories.svelte.ts
@@ -9,6 +9,7 @@
 
 import { categoriesData, enrichmentLiveCategories, enrichmentLiveVersion } from "$lib/api";
 import { settings } from "$lib/stores/settings.svelte";
+import { isLinux } from "$lib/util/platform";
 import type { CategoriesData, PackageKind } from "$lib/types";
 
 interface CategoryTile {
@@ -87,12 +88,18 @@ class CategoriesStore {
   /**
    * Sorted tile list for the Discover grid. `developer-tools` first (largest),
    * `uncategorized` always last, the rest by descending count.
+   *
+   * Linux: the bundled categories.json is platform-agnostic and carries cask
+   * tokens, but casks don't exist on Linux — they're excluded from the tile
+   * counts so the numbers match the (cask-free) browse lists.
    */
   tiles = $derived.by<CategoryTile[]>(() => {
     if (!this.data) return [];
     const counts = new Map<string, number>();
-    for (const cats of Object.values(this.data.casks)) {
-      for (const c of cats) counts.set(c, (counts.get(c) ?? 0) + 1);
+    if (!isLinux) {
+      for (const cats of Object.values(this.data.casks)) {
+        for (const c of cats) counts.set(c, (counts.get(c) ?? 0) + 1);
+      }
     }
     for (const cats of Object.values(this.data.formulae)) {
       for (const c of cats) counts.set(c, (counts.get(c) ?? 0) + 1);

--- a/src/lib/stores/env.svelte.ts
+++ b/src/lib/stores/env.svelte.ts
@@ -2,11 +2,16 @@
  * Environment store — tracks the `brew_doctor` probe result.
  * Drives the footer status dot (green / amber / red), tooltip text, and
  * the "Homebrew not found" empty/error states.
+ *
+ * Also owns the missing-Homebrew onboarding gate: `system_status` on
+ * startup, then a 2 s `brew_redetect` poll while brew is missing. The
+ * moment brew appears, polling stops and the library loads — no relaunch.
  */
 
-import { brewDoctor } from "$lib/api";
+import { brewDoctor, brewRedetect, systemStatus } from "$lib/api";
+import { packages } from "$lib/stores/packages.svelte";
 import { isBrewError, brewErrorMessage } from "$lib/types";
-import type { BrewEnvironment } from "$lib/types";
+import type { BrewEnvironment, SystemStatus } from "$lib/types";
 
 class EnvStore {
   /** latest BrewEnvironment from the backend, or null until first probe completes. */
@@ -18,8 +23,24 @@ class EnvStore {
   /** ms-since-epoch of the last completed probe (success or fail). */
   lastCheckedAt: number | null = $state(null);
 
+  /** Latest `system_status` / `brew_redetect` snapshot (onboarding gate). */
+  status: SystemStatus | null = $state(null);
+  /** True once the initial `system_status` probe has settled (success or fail). */
+  statusChecked: boolean = $state(false);
+
+  /** 2 s `brew_redetect` poll handle while brew is missing. */
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
   /** True when we have a confirmed-installed brew. False if probe failed or installed=false. */
   installed = $derived(this.report?.installed === true);
+
+  /**
+   * Onboarding gate: brew is *confirmed* missing (probe settled and said
+   * no). `+page.svelte` renders OnboardingView instead of the shell while
+   * this is true. Stays false until the first probe settles so a slow IPC
+   * round-trip doesn't flash the onboarding screen at users who have brew.
+   */
+  brewMissing = $derived(this.statusChecked && this.status?.brewFound === false);
 
   /** Human-readable summary for a tooltip. */
   summary = $derived.by(() => {
@@ -74,6 +95,57 @@ class EnvStore {
     }
     await this.refresh();
   }
+
+  /**
+   * Initial onboarding probe. On failure (backend not ready, command
+   * missing) the gate stays open — `brewMissing` remains false and the
+   * packages store's `brew_not_found` message is the fallback.
+   */
+  async checkSystemStatus(): Promise<void> {
+    try {
+      this.applyStatus(await systemStatus());
+    } catch {
+      this.statusChecked = true;
+    }
+  }
+
+  /**
+   * Fold a status snapshot into state and manage the redetect poll:
+   * brew missing → keep (or start) the 2 s poll; brew present → stop
+   * polling, and if this is the missing→found flip, re-probe the env and
+   * force-load the library so the app comes alive without a relaunch.
+   */
+  applyStatus(s: SystemStatus): void {
+    const wasMissing = this.status?.brewFound === false;
+    this.status = s;
+    this.statusChecked = true;
+    if (!s.brewFound) {
+      this.startBrewPolling();
+    } else {
+      this.stopBrewPolling();
+      if (wasMissing) {
+        void this.refresh();
+        void packages.load(true);
+      }
+    }
+  }
+
+  private startBrewPolling(): void {
+    if (this.pollTimer !== null) return;
+    this.pollTimer = setInterval(() => {
+      void brewRedetect().then(
+        (s) => this.applyStatus(s),
+        () => {}, // transient IPC failure — keep polling
+      );
+    }, 2_000);
+  }
+
+  stopBrewPolling(): void {
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
 }
 
 export const env = new EnvStore();
@@ -118,4 +190,15 @@ export function startEnvProbe(): () => void {
     }
     if (intervalId !== null) clearInterval(intervalId);
   };
+}
+
+/**
+ * Onboarding gate bootstrap — run the initial `system_status` probe;
+ * `applyStatus` keeps a 2 s `brew_redetect` poll alive while brew is
+ * missing and tears it down (plus loads the library) the moment it
+ * appears. Returns an unsubscribe that stops any in-flight polling.
+ */
+export function startOnboardingGate(): () => void {
+  void env.checkSystemStatus();
+  return () => env.stopBrewPolling();
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,8 @@
  * `invoke()` returns for each Tauri command.
  */
 
+import { keyringNameCapitalized } from "$lib/util/platform";
+
 // =========================================================
 // 2.1 Common enums
 // =========================================================
@@ -41,6 +43,17 @@ export interface BrewEnvironment {
   version: string | null;
   prefix: string | null;
   pathUsed: string | null;
+}
+
+/**
+ * Snapshot from `system_status` / `brew_redetect` that drives the
+ * missing-Homebrew onboarding gate. `cltFound` is the Xcode Command Line
+ * Tools probe (`xcode-select -p`); always `true` on non-macOS builds.
+ */
+export interface SystemStatus {
+  brewFound: boolean;
+  brewPath: string | null;
+  cltFound: boolean;
 }
 
 // =========================================================
@@ -898,7 +911,7 @@ export function brewErrorMessage(e: BrewErrorPayload): string {
       return `GitHub API rate limit reached. Resets at ${reset}. Sign in to lift the limit.`;
     }
     case "keychain_unavailable":
-      return `macOS Keychain unavailable: ${e.message}`;
+      return `${keyringNameCapitalized} unavailable: ${e.message}`;
     case "auth_required":
       return "Sign in to GitHub to use this feature.";
     case "scope_required":

--- a/src/lib/util/platform.ts
+++ b/src/lib/util/platform.ts
@@ -1,0 +1,31 @@
+/**
+ * Host-OS detection for the renderer — the single source of truth for
+ * platform-aware user-facing copy (e.g. "Reveal in Finder" on macOS vs
+ * "Show in file manager" on Linux).
+ *
+ * Why navigator-based and not `@tauri-apps/plugin-os`: that plugin is not a
+ * dependency, and adding one for a handful of label swaps isn't worth the
+ * weight. The WebView's `navigator.userAgent` faithfully reflects the host OS
+ * — macOS reports "Macintosh"/"Mac OS X", Linux reports "Linux"/"X11". That's
+ * more than precise enough for choosing a noun in a button label.
+ *
+ * Evaluated once at module load: the host OS does not change mid-session.
+ */
+const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
+
+/** True when running on macOS. Defaults to true under SSR/no-navigator so the
+ *  static build (and any non-WebView render) keeps the macOS wording. */
+export const isMac = ua === "" || /Mac|Macintosh|Mac OS X/i.test(ua);
+
+/** True when running on Linux (X11/Wayland WebView). */
+export const isLinux = /Linux|X11/i.test(ua) && !isMac;
+
+/** The OS file manager's name, for interpolation into copy. */
+export const fileManagerName = isMac ? "Finder" : "file manager";
+
+/** The OS credential store's name, for mid-sentence interpolation. */
+export const keyringName = isMac ? "macOS Keychain" : "system keyring";
+
+/** Sentence-leading form of {@link keyringName} ("macOS Keychain" already
+ *  starts uppercase; "system keyring" becomes "System keyring"). */
+export const keyringNameCapitalized = isMac ? "macOS Keychain" : "System keyring";

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
   import { onMount } from "svelte";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { ui, watchSystemTheme } from "$lib/stores/ui.svelte";
-  import { startEnvProbe } from "$lib/stores/env.svelte";
+  import { startEnvProbe, startOnboardingGate } from "$lib/stores/env.svelte";
   import { activity } from "$lib/stores/activity.svelte";
   import { services } from "$lib/stores/services.svelte";
   import { settings } from "$lib/stores/settings.svelte";
@@ -66,9 +66,14 @@
 
     const unwatch = watchSystemTheme(() => ui.theme);
     const stopProbe = startEnvProbe();
+    // Missing-Homebrew onboarding gate: one system_status probe, then a
+    // 2 s brew_redetect poll while brew is missing. `+page.svelte` swaps
+    // the shell for OnboardingView via `env.brewMissing`.
+    const stopOnboarding = startOnboardingGate();
     return () => {
       unwatch();
       stopProbe();
+      stopOnboarding();
       unlistenAbout?.();
       unlistenSettings?.();
     };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   import Snapshots from "$lib/components/Snapshots.svelte";
   import Services from "$lib/components/Services.svelte";
   import ActivityHistory from "$lib/components/ActivityHistory.svelte";
+  import OnboardingView from "$lib/components/OnboardingView.svelte";
   import PackageDetail from "$lib/components/PackageDetail.svelte";
   import ResizeHandle from "$lib/components/ResizeHandle.svelte";
   import ActivityDrawer from "$lib/components/ActivityDrawer.svelte";
@@ -24,6 +25,7 @@
 
   import { ui } from "$lib/stores/ui.svelte";
   import { DETAIL_PANE_MIN_WIDTH, DETAIL_PANE_DEFAULT_WIDTH, clampDetailPaneWidth } from "$lib/stores/ui.svelte";
+  import { env } from "$lib/stores/env.svelte";
   import { packages } from "$lib/stores/packages.svelte";
   import { brewfiles } from "$lib/stores/brewfiles.svelte";
   import { trending } from "$lib/stores/trending.svelte";
@@ -186,40 +188,48 @@
     </div>
   </header>
   <div class="main">
-    <Sidebar />
-    <main class="content">
-      {#key ui.section}
-        <div class="section-pane">
-          {#if ui.section === "dashboard"}
-            <Dashboard />
-          {:else if ui.section === "library"}
-            <Library />
-          {:else if ui.section === "discover"}
-            <Discover />
-          {:else if ui.section === "trending"}
-            <Trending />
-          {:else if ui.section === "snapshots"}
-            <Snapshots />
-          {:else if ui.section === "services"}
-            <Services />
-          {:else if ui.section === "activity"}
-            <ActivityHistory />
-          {/if}
-        </div>
-      {/key}
-    </main>
-    {#if ui.selectedPackage}
-      <ResizeHandle
-        width={ui.detailPaneWidth}
-        min={DETAIL_PANE_MIN_WIDTH}
-        max={detailPaneMax}
-        defaultWidth={DETAIL_PANE_DEFAULT_WIDTH}
-        direction="left"
-        label="Resize package detail panel"
-        onChange={(w) => (ui.detailPaneWidth = w)}
-        onCommit={(w) => ui.setDetailPaneWidth(w)}
-      />
-      <PackageDetail />
+    {#if env.brewMissing}
+      <!-- Onboarding gate: brew is confirmed missing — replace the whole
+           shell (sidebar + sections + detail pane) with the setup view.
+           The env store polls brew_redetect every 2 s and flips this off
+           (plus loads the library) the moment the install lands. -->
+      <OnboardingView />
+    {:else}
+      <Sidebar />
+      <main class="content">
+        {#key ui.section}
+          <div class="section-pane">
+            {#if ui.section === "dashboard"}
+              <Dashboard />
+            {:else if ui.section === "library"}
+              <Library />
+            {:else if ui.section === "discover"}
+              <Discover />
+            {:else if ui.section === "trending"}
+              <Trending />
+            {:else if ui.section === "snapshots"}
+              <Snapshots />
+            {:else if ui.section === "services"}
+              <Services />
+            {:else if ui.section === "activity"}
+              <ActivityHistory />
+            {/if}
+          </div>
+        {/key}
+      </main>
+      {#if ui.selectedPackage}
+        <ResizeHandle
+          width={ui.detailPaneWidth}
+          min={DETAIL_PANE_MIN_WIDTH}
+          max={detailPaneMax}
+          defaultWidth={DETAIL_PANE_DEFAULT_WIDTH}
+          direction="left"
+          label="Resize package detail panel"
+          onChange={(w) => (ui.detailPaneWidth = w)}
+          onCommit={(w) => ui.setDetailPaneWidth(w)}
+        />
+        <PackageDetail />
+      {/if}
     {/if}
   </div>
   <ActivityDrawer />

--- a/tools/build/sign-and-notarize.sh
+++ b/tools/build/sign-and-notarize.sh
@@ -3,8 +3,22 @@
 #
 # Usage:   source ~/.config/brew-browser/signing.env && ./tools/build/sign-and-notarize.sh
 #
-# Runs: cargo tauri build → notarize+staple the .dmg → verify with spctl.
+# Runs: cargo tauri build → notarize+staple the .dmg(s) → verify with spctl.
 # Requires: APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID env vars set (see BUILD.md).
+#
+# Architectures — two build commands, two bundle roots:
+#   npm run tauri build
+#       → arm64 (host) bundles under src-tauri/target/release/bundle/
+#         (artifacts named `_aarch64`)
+#   npm run tauri build -- --target x86_64-apple-darwin
+#       → Intel bundles under src-tauri/target/x86_64-apple-darwin/release/bundle/
+#         (Tauri names Intel artifacts `_x64`; one-time setup:
+#          rustup target add x86_64-apple-darwin)
+# This script always runs the arm64 build itself, then signs/notarizes/staples
+# every bundle it finds for BOTH arches. For a dual-arch release, run the
+# x86_64 build (with signing.env sourced) before invoking this script. When
+# the x86_64 bundles are absent the arch is skipped with a warning, so
+# single-arch (arm64-only) releases keep working unchanged.
 
 set -euo pipefail
 
@@ -69,56 +83,89 @@ echo
 echo "▸ npm run tauri build (compile + sign .app + sign .app.tar.gz + bundle .dmg)"
 npm run tauri build
 
-# Locate the produced .dmg (version-agnostic)
-DMG="$(ls -t src-tauri/target/release/bundle/dmg/brew-browser_*_aarch64.dmg 2>/dev/null | head -1 || true)"
-if [[ -z "$DMG" || ! -f "$DMG" ]]; then
-  echo "✗ build completed but no .dmg found under src-tauri/target/release/bundle/dmg/" >&2
+# ─── Locate the produced bundles (per arch, version-agnostic) ────────────────
+
+AARCH64_BUNDLE="src-tauri/target/release/bundle"
+X64_BUNDLE="src-tauri/target/x86_64-apple-darwin/release/bundle"
+
+DMGS=()
+
+# arm64 — mandatory; this script just built it.
+DMG_AARCH64="$(ls -t "$AARCH64_BUNDLE"/dmg/brew-browser_*_aarch64.dmg 2>/dev/null | head -1 || true)"
+if [[ -z "$DMG_AARCH64" || ! -f "$DMG_AARCH64" ]]; then
+  echo "✗ build completed but no .dmg found under $AARCH64_BUNDLE/dmg/" >&2
   exit 1
 fi
+DMGS+=("$DMG_AARCH64")
 echo
-echo "▸ .dmg produced: $DMG"
+echo "▸ arm64 .dmg produced: $DMG_AARCH64"
 
-# Phase 15 — confirm the updater .app.tar.gz + .sig also exist. These
-# are what `tools/release/publish-manifest.sh` hashes and references in
-# the manifest URL; a release without them ships a working .dmg fresh-
-# install path but a broken auto-updater path.
-APP_TAR_GZ="src-tauri/target/release/bundle/macos/brew-browser.app.tar.gz"
-APP_TAR_GZ_SIG="${APP_TAR_GZ}.sig"
-if [[ ! -f "$APP_TAR_GZ" ]]; then
-  echo "✗ updater artifact missing: $APP_TAR_GZ" >&2
-  echo "  Tauri should emit this automatically when the updater plugin is" >&2
-  echo "  registered AND TAURI_SIGNING_PRIVATE_KEY[_PATH] is set." >&2
-  exit 1
+# x86_64 — optional; built separately via
+# `npm run tauri build -- --target x86_64-apple-darwin`. Skip-if-absent so
+# arm64-only releases keep working unchanged.
+DMG_X64="$(ls -t "$X64_BUNDLE"/dmg/brew-browser_*_x64.dmg 2>/dev/null | head -1 || true)"
+if [[ -n "$DMG_X64" && -f "$DMG_X64" ]]; then
+  DMGS+=("$DMG_X64")
+  echo "▸ x86_64 .dmg found: $DMG_X64"
+else
+  echo "⚠ no x86_64 .dmg under $X64_BUNDLE/dmg/ — this will be an arm64-only release." >&2
+  echo "  For a dual-arch release, run 'npm run tauri build -- --target x86_64-apple-darwin'" >&2
+  echo "  (with signing.env sourced) before this script." >&2
 fi
-if [[ ! -f "$APP_TAR_GZ_SIG" ]]; then
-  echo "✗ updater signature missing: $APP_TAR_GZ_SIG" >&2
-  echo "  The TAURI_SIGNING_PRIVATE_KEY env vars probably weren't used by the build." >&2
-  exit 1
+
+# Phase 15 — confirm the updater .app.tar.gz + .sig also exist for every
+# arch we're shipping. These are what `tools/release/publish-manifest.sh`
+# hashes and references in the manifest URL; a release without them ships
+# a working .dmg fresh-install path but a broken auto-updater path.
+require_updater_artifacts() {
+  local arch="$1" bundle_root="$2"
+  local app_tar_gz="$bundle_root/macos/brew-browser.app.tar.gz"
+  local app_tar_gz_sig="${app_tar_gz}.sig"
+  if [[ ! -f "$app_tar_gz" ]]; then
+    echo "✗ $arch updater artifact missing: $app_tar_gz" >&2
+    echo "  Tauri should emit this automatically when the updater plugin is" >&2
+    echo "  registered AND TAURI_SIGNING_PRIVATE_KEY[_PATH] is set." >&2
+    exit 1
+  fi
+  if [[ ! -f "$app_tar_gz_sig" ]]; then
+    echo "✗ $arch updater signature missing: $app_tar_gz_sig" >&2
+    echo "  The TAURI_SIGNING_PRIVATE_KEY env vars probably weren't used by the build." >&2
+    exit 1
+  fi
+  echo "▸ $arch updater artifact: $app_tar_gz"
+  echo "▸ $arch updater signature: $app_tar_gz_sig"
+}
+
+require_updater_artifacts arm64 "$AARCH64_BUNDLE"
+if [[ -n "$DMG_X64" ]]; then
+  require_updater_artifacts x86_64 "$X64_BUNDLE"
 fi
-echo "▸ updater artifact: $APP_TAR_GZ"
-echo "▸ updater signature: $APP_TAR_GZ_SIG"
 
-# ─── Notarize + staple the .dmg wrapper itself ───────────────────────────────
+# ─── Notarize + staple each .dmg wrapper itself ──────────────────────────────
 
-echo
-echo "▸ submitting .dmg to Apple notary (waiting for ticket — typically 1-5 min)"
-xcrun notarytool submit "$DMG" \
-  --apple-id "$APPLE_ID" \
-  --password "$APPLE_PASSWORD" \
-  --team-id "$APPLE_TEAM_ID" \
-  --wait
+for DMG in "${DMGS[@]}"; do
+  echo
+  echo "▸ submitting $(basename "$DMG") to Apple notary (waiting for ticket — typically 1-5 min)"
+  xcrun notarytool submit "$DMG" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" \
+    --wait
 
-echo
-echo "▸ stapling notarization ticket to .dmg"
-xcrun stapler staple "$DMG"
+  echo
+  echo "▸ stapling notarization ticket to $(basename "$DMG")"
+  xcrun stapler staple "$DMG"
+done
 
 # ─── Verify ──────────────────────────────────────────────────────────────────
 
 echo
 echo "▸ verification"
-spctl --assess --type install --verbose=4 "$DMG"
-xcrun stapler validate "$DMG"
+for DMG in "${DMGS[@]}"; do
+  spctl --assess --type install --verbose=4 "$DMG"
+  xcrun stapler validate "$DMG"
+done
 
 echo
-echo "✓ done — $DMG is signed, notarized, stapled, and ready to ship"
-ls -lh "$DMG"
+echo "✓ done — ${#DMGS[@]} .dmg(s) signed, notarized, stapled, and ready to ship"
+ls -lh "${DMGS[@]}"

--- a/tools/release/publish-manifest.sh
+++ b/tools/release/publish-manifest.sh
@@ -6,8 +6,13 @@
 #
 # What it does:
 #   1. Validates the version argument shape.
-#   2. Locates the .app.tar.gz artifact at the canonical macos bundle
-#      path. **The Tauri updater plugin's macOS install path expects a
+#   2. Locates the .app.tar.gz artifact(s) at the canonical macos bundle
+#      paths — arm64 under target/release/bundle, x86_64 under
+#      target/x86_64-apple-darwin/release/bundle (Tauri names Intel
+#      artifacts `_x64`). The arm64 artifact is mandatory; the x86_64
+#      one is optional and its platform key is omitted (with a loud
+#      warning) when absent, so arm64-only releases keep working.
+#      **The Tauri updater plugin's macOS install path expects a
 #      gzipped tar of the .app bundle — NOT the .dmg.** Feeding it a
 #      .dmg results in an "invalid gzip" error on every install attempt.
 #      The .dmg is still uploaded to GitHub Releases for fresh installs;
@@ -31,6 +36,11 @@
 #              "signature": "<contents of .app.tar.gz.sig, single-line>",
 #              "url": "<github release asset URL of the .app.tar.gz>",
 #              "sha256": "<artifact digest>"
+#            },
+#            "darwin-x86_64": {  // only when the _x64 artifact exists
+#              "signature": "...",
+#              "url": "...",
+#              "sha256": "..."
 #            }
 #          }
 #        }
@@ -82,31 +92,71 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # The Tauri bundler emits the updater artifact + signature at these
-# paths. Filenames are fixed (no version stamp) inside `bundle/macos/`;
-# we upload to GitHub Releases under versioned names so the manifest
-# URL is unambiguous.
-ARTIFACT_PATH="$REPO_ROOT/src-tauri/target/release/bundle/macos/brew-browser.app.tar.gz"
-SIGNATURE_FILE="${ARTIFACT_PATH}.sig"
-# Versioned name used in the published GitHub Release asset URL.
-ARTIFACT_RELEASE_NAME="brew-browser_${VERSION}_aarch64.app.tar.gz"
+# paths — one bundle root per arch. Filenames are fixed (no version or
+# arch stamp) inside each `bundle/macos/`; we upload to GitHub Releases
+# under versioned, arch-stamped names so the manifest URLs are
+# unambiguous (Tauri's own artifact naming: arm64 = `_aarch64`,
+# Intel = `_x64`).
+AARCH64_ARTIFACT_PATH="$REPO_ROOT/src-tauri/target/release/bundle/macos/brew-browser.app.tar.gz"
+AARCH64_SIGNATURE_FILE="${AARCH64_ARTIFACT_PATH}.sig"
+AARCH64_RELEASE_NAME="brew-browser_${VERSION}_aarch64.app.tar.gz"
+X64_ARTIFACT_PATH="$REPO_ROOT/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/brew-browser.app.tar.gz"
+X64_SIGNATURE_FILE="${X64_ARTIFACT_PATH}.sig"
+X64_RELEASE_NAME="brew-browser_${VERSION}_x64.app.tar.gz"
 DIST_DIR="$REPO_ROOT/dist"
 MANIFEST_PATH="$DIST_DIR/updater.json"
 
+# Linux updater artifact. Tauri's Linux updater install path uses the
+# .AppImage (NOT the .deb/.rpm), and signs it with the same
+# TAURI_SIGNING_PRIVATE_KEY (minisign is cross-platform). The bundler
+# stamps the AppImage with the version + arch, so glob for it rather
+# than hard-coding the name. This block is OPTIONAL: when running on a
+# Mac that only built the .app.tar.gz, no AppImage exists and we emit a
+# macOS-only manifest exactly as before.
+LINUX_ARTIFACT_PATH="$(ls -t "$REPO_ROOT"/src-tauri/target/release/bundle/appimage/*.AppImage 2>/dev/null | head -1 || true)"
+LINUX_ARTIFACT_RELEASE_NAME="brew-browser_${VERSION}_amd64.AppImage"
+
 # ---------- Preflight ----------
 
-if [[ ! -f "$ARTIFACT_PATH" ]]; then
-    echo "error: updater artifact not found at $ARTIFACT_PATH" >&2
+if [[ ! -f "$AARCH64_ARTIFACT_PATH" ]]; then
+    echo "error: updater artifact not found at $AARCH64_ARTIFACT_PATH" >&2
     echo "  did you run 'npm run tauri build' first?" >&2
     echo "  the macOS updater target produces .app.tar.gz alongside the .dmg." >&2
     exit 2
 fi
 
-if [[ ! -f "$SIGNATURE_FILE" ]]; then
-    echo "error: updater signature not found at $SIGNATURE_FILE" >&2
+if [[ ! -f "$AARCH64_SIGNATURE_FILE" ]]; then
+    echo "error: updater signature not found at $AARCH64_SIGNATURE_FILE" >&2
     echo "  The Tauri bundler produces this when TAURI_SIGNING_PRIVATE_KEY[_PATH]" >&2
     echo "  + TAURI_SIGNING_PRIVATE_KEY_PASSWORD are set during 'npm run tauri build'." >&2
     echo "  Source ~/.config/brew-browser/signing.env, then re-run the build." >&2
     exit 2
+fi
+
+# x86_64 is optional — omit its platform key (loudly) when the artifact
+# is absent rather than failing, so an arm64-only release still ships.
+# An artifact WITHOUT its .sig is a broken build, not an absent arch:
+# fail in that case exactly like the aarch64 path.
+HAVE_X64=0
+if [[ -f "$X64_ARTIFACT_PATH" ]]; then
+    if [[ ! -f "$X64_SIGNATURE_FILE" ]]; then
+        echo "error: x86_64 updater signature not found at $X64_SIGNATURE_FILE" >&2
+        echo "  The artifact exists but its .sig is missing — the TAURI_SIGNING_*" >&2
+        echo "  env vars probably weren't set during the x86_64 build. Re-run" >&2
+        echo "  'npm run tauri build -- --target x86_64-apple-darwin' with" >&2
+        echo "  signing.env sourced." >&2
+        exit 2
+    fi
+    HAVE_X64=1
+else
+    echo "" >&2
+    echo "⚠⚠⚠ WARNING: no x86_64 updater artifact at $X64_ARTIFACT_PATH" >&2
+    echo "    The manifest will contain ONLY darwin-aarch64 — Intel users get" >&2
+    echo "    no auto-update for v${VERSION}. For a dual-arch release, run" >&2
+    echo "    'npm run tauri build -- --target x86_64-apple-darwin' first" >&2
+    echo "    (one-time: rustup target add x86_64-apple-darwin), then re-run" >&2
+    echo "    this script." >&2
+    echo "" >&2
 fi
 
 if ! command -v shasum >/dev/null 2>&1; then
@@ -115,26 +165,83 @@ if ! command -v shasum >/dev/null 2>&1; then
     exit 3
 fi
 
-# ---------- Compute hash ----------
+# ---------- Compute hashes ----------
 
-echo "info: computing SHA-256 of $(basename "$ARTIFACT_PATH")..." >&2
-SHA256=$(shasum -a 256 "$ARTIFACT_PATH" | awk '{print $1}')
-echo "info: sha256 = $SHA256" >&2
+echo "info: computing SHA-256 of aarch64 $(basename "$AARCH64_ARTIFACT_PATH")..." >&2
+AARCH64_SHA256=$(shasum -a 256 "$AARCH64_ARTIFACT_PATH" | awk '{print $1}')
+echo "info: aarch64 sha256 = $AARCH64_SHA256" >&2
+if [[ $HAVE_X64 -eq 1 ]]; then
+    echo "info: computing SHA-256 of x86_64 $(basename "$X64_ARTIFACT_PATH")..." >&2
+    X64_SHA256=$(shasum -a 256 "$X64_ARTIFACT_PATH" | awk '{print $1}')
+    echo "info: x86_64 sha256 = $X64_SHA256" >&2
+fi
 
-# ---------- Read signature ----------
+# ---------- Read signatures ----------
 
 # Tauri's bundler emits a single-line base64 blob in the .sig file
 # (Tauri's format, NOT raw minisign's multi-line .minisig format).
 # The plugin's verification path reads this string directly and parses
 # it against the embedded pubkey; do not re-encode.
-SIGNATURE_RAW=$(cat "$SIGNATURE_FILE")
-# Trim trailing newline if present (shasum + cat both append one).
-SIGNATURE_JSON="${SIGNATURE_RAW%$'\n'}"
-# Defensive: JSON-escape any literal newlines (Tauri's .sig is normally
-# a single line but be belt-and-braces in case bundler version drift
-# changes the shape).
-SIGNATURE_JSON=$(perl -pe 's/\n/\\n/g' <<< "$SIGNATURE_JSON")
-SIGNATURE_JSON="${SIGNATURE_JSON%\\n}"
+read_signature() {
+    local raw
+    raw=$(cat "$1")
+    # Trim trailing newline if present (cat's $() strips it, but be safe).
+    raw="${raw%$'\n'}"
+    # Defensive: JSON-escape any literal newlines (Tauri's .sig is normally
+    # a single line but be belt-and-braces in case bundler version drift
+    # changes the shape).
+    raw=$(perl -pe 's/\n/\\n/g' <<< "$raw")
+    printf '%s' "${raw%\\n}"
+}
+
+AARCH64_SIGNATURE_JSON=$(read_signature "$AARCH64_SIGNATURE_FILE")
+if [[ $HAVE_X64 -eq 1 ]]; then
+    X64_SIGNATURE_JSON=$(read_signature "$X64_SIGNATURE_FILE")
+fi
+
+# ---------- Linux platform block (conditional) ----------
+
+# Build the linux-x86_64 platform entry only when the AppImage + its
+# .sig are both present. Absent (Mac-only build) → LINUX_BLOCK stays
+# empty and the manifest is macOS-only, byte-for-byte as before.
+LINUX_BLOCK=""
+if [[ -n "$LINUX_ARTIFACT_PATH" && -f "$LINUX_ARTIFACT_PATH" ]]; then
+    LINUX_SIGNATURE_FILE="${LINUX_ARTIFACT_PATH}.sig"
+    if [[ ! -f "$LINUX_SIGNATURE_FILE" ]]; then
+        echo "error: found AppImage but its signature is missing:" >&2
+        echo "  $LINUX_SIGNATURE_FILE" >&2
+        echo "  Tauri produces this when TAURI_SIGNING_PRIVATE_KEY[_PATH] is set" >&2
+        echo "  during the Linux 'npm run tauri build'. Re-run with signing env." >&2
+        exit 2
+    fi
+
+    echo "info: computing SHA-256 of $(basename "$LINUX_ARTIFACT_PATH")..." >&2
+    LINUX_SHA256=$(shasum -a 256 "$LINUX_ARTIFACT_PATH" | awk '{print $1}')
+    echo "info: linux sha256 = $LINUX_SHA256" >&2
+
+    # Same single-line Tauri .sig format + defensive newline-escaping as
+    # the macOS signature above.
+    LINUX_SIGNATURE_RAW=$(cat "$LINUX_SIGNATURE_FILE")
+    LINUX_SIGNATURE_JSON="${LINUX_SIGNATURE_RAW%$'\n'}"
+    LINUX_SIGNATURE_JSON=$(perl -pe 's/\n/\\n/g' <<< "$LINUX_SIGNATURE_JSON")
+    LINUX_SIGNATURE_JSON="${LINUX_SIGNATURE_JSON%\\n}"
+
+    LINUX_URL="https://github.com/msitarzewski/brew-browser/releases/download/v${VERSION}/${LINUX_ARTIFACT_RELEASE_NAME}"
+
+    # Leading comma + newline so it appends cleanly after the
+    # darwin-aarch64 entry inside the "platforms" object.
+    LINUX_BLOCK=$(cat <<EOF
+,
+    "linux-x86_64": {
+      "signature": "${LINUX_SIGNATURE_JSON}",
+      "url": "${LINUX_URL}",
+      "sha256": "${LINUX_SHA256}"
+    }
+EOF
+)
+else
+    echo "info: no Linux AppImage found — emitting macOS-only manifest." >&2
+fi
 
 # ---------- Emit manifest ----------
 
@@ -145,7 +252,22 @@ mkdir -p "$DIST_DIR"
 # the manifest generator and the release notes editorial step separate
 # is the simpler shape than wiring CHANGELOG parsing here.
 PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-URL="https://github.com/msitarzewski/brew-browser/releases/download/v${VERSION}/${ARTIFACT_RELEASE_NAME}"
+AARCH64_URL="https://github.com/msitarzewski/brew-browser/releases/download/v${VERSION}/${AARCH64_RELEASE_NAME}"
+X64_URL="https://github.com/msitarzewski/brew-browser/releases/download/v${VERSION}/${X64_RELEASE_NAME}"
+
+PLATFORMS_JSON="    \"darwin-aarch64\": {
+      \"signature\": \"${AARCH64_SIGNATURE_JSON}\",
+      \"url\": \"${AARCH64_URL}\",
+      \"sha256\": \"${AARCH64_SHA256}\"
+    }"
+if [[ $HAVE_X64 -eq 1 ]]; then
+    PLATFORMS_JSON="${PLATFORMS_JSON},
+    \"darwin-x86_64\": {
+      \"signature\": \"${X64_SIGNATURE_JSON}\",
+      \"url\": \"${X64_URL}\",
+      \"sha256\": \"${X64_SHA256}\"
+    }"
+fi
 
 cat > "$MANIFEST_PATH" <<EOF
 {
@@ -153,30 +275,42 @@ cat > "$MANIFEST_PATH" <<EOF
   "notes": "See https://github.com/msitarzewski/brew-browser/releases/tag/v${VERSION} for release notes.",
   "pub_date": "${PUB_DATE}",
   "platforms": {
-    "darwin-aarch64": {
-      "signature": "${SIGNATURE_JSON}",
-      "url": "${URL}",
-      "sha256": "${SHA256}"
-    }
+${PLATFORMS_JSON}${LINUX_BLOCK}
   }
 }
 EOF
 
 echo ""
 echo "✓ manifest written to: $MANIFEST_PATH"
-echo "  version:    $VERSION"
-echo "  sha256:     $SHA256"
-echo "  url:        $URL"
-echo "  pub_date:   $PUB_DATE"
-echo "  signature:  $(wc -c < "$SIGNATURE_FILE" | tr -d ' ') bytes from $SIGNATURE_FILE"
+echo "  version:           $VERSION"
+echo "  pub_date:          $PUB_DATE"
+echo "  aarch64 sha256:    $AARCH64_SHA256"
+echo "  aarch64 url:       $AARCH64_URL"
+echo "  aarch64 signature: $(wc -c < "$AARCH64_SIGNATURE_FILE" | tr -d ' ') bytes from $AARCH64_SIGNATURE_FILE"
+if [[ $HAVE_X64 -eq 1 ]]; then
+    echo "  x86_64 sha256:     $X64_SHA256"
+    echo "  x86_64 url:        $X64_URL"
+    echo "  x86_64 signature:  $(wc -c < "$X64_SIGNATURE_FILE" | tr -d ' ') bytes from $X64_SIGNATURE_FILE"
+else
+    echo "  x86_64:            ABSENT — darwin-x86_64 key omitted (see warning above)"
+fi
 echo ""
 echo "next steps (run manually):"
 echo "  1. rsync -av $MANIFEST_PATH umacbookpro:Sites/brew-browser/updater.json"
 echo "  2. gh release create v${VERSION} \\"
 echo "       src-tauri/target/release/bundle/dmg/brew-browser_${VERSION}_aarch64.dmg \\"
-echo "       $ARTIFACT_PATH#${ARTIFACT_RELEASE_NAME} \\"
+if [[ $HAVE_X64 -eq 1 ]]; then
+    echo "       src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/brew-browser_${VERSION}_x64.dmg \\"
+fi
+echo "       $AARCH64_ARTIFACT_PATH#${AARCH64_RELEASE_NAME} \\"
+if [[ $HAVE_X64 -eq 1 ]]; then
+    echo "       $X64_ARTIFACT_PATH#${X64_RELEASE_NAME} \\"
+fi
 echo "       --notes-file <release-notes.md>"
 echo ""
 echo "verify before publishing:"
-echo "  shasum -a 256 $ARTIFACT_PATH"
+echo "  shasum -a 256 $AARCH64_ARTIFACT_PATH"
+if [[ $HAVE_X64 -eq 1 ]]; then
+    echo "  shasum -a 256 $X64_ARTIFACT_PATH"
+fi
 echo "  curl -s https://brew-browser.zerologic.com/updater.json | jq"


### PR DESCRIPTION
## Why

Post-0.5.1 reports of "corrupt" native downloads turned out to be Intel Mac users opening arm64-only dmgs (every shipped artifact audited bit-perfect — signatures, notarization, staples, Sparkle EdDSA all verified). This PR makes sure no Mac (or Linux box) hits a dead end again.

## What

### 1. Missing-Homebrew onboarding (both shells)
- brew missing → guided first-run view instead of a dead-end error string: CLT step (macOS), apt build-deps note (Linux), official install one-liner with **Copy** (primary) and **Open Terminal** (macOS only; fixed-constant command, zero interpolation — the installer never runs inside the app)
- 2-second prefix poll → the moment brew appears, the same process dissolves into the loaded library; no relaunch
- Fixes `VulnsService` silently falling back to a hardcoded `/opt/homebrew/bin/brew`
- **Verified live on Ubuntu**: real Homebrew uninstall → onboarding → real reinstall → automatic recovery

### 2. Intel builds (separate per-arch artifacts, not universal)
- Tauri: x86_64 supported through the release tooling — per-arch dmg sign/notarize, gated `darwin-x86_64` updater-manifest key; first `_x64.dmg` built and arch-verified
- Native: `build-app.sh [debug|release] [arm64|x86_64]`; `release.sh` loops both arches into arch-suffixed zips/dmgs, and `generate_appcast` now runs before dmg creation (fixes future appcast scan pollution)
- README + landing get a "which download?" guide

### 3. Linux support (from `282d8ff`, rebased + integrated)
- Per-target keyring features, Linuxbrew prefix detection, exec cwd pinning, cfg-gated reveal/icons/menu, `tauri.linux.conf.json`, CI workflow
- deb/rpm/AppImage **built, installed, and runtime-verified** in a GNOME Wayland VM (real installs, vuln scanning, the works)
- **Casks fully gated off Linux** — they're a macOS-only concept: data layer (empty cask catalog, `brew search --cask` never spawned) plus a UI terminology sweep (Dashboard, Library, Trending, Discover, Settings, Snapshots, About). macOS rendering byte-identical.

## QA

cargo **618 passed** · svelte-check **0 errors** (3 baseline warnings) · swift **44 passed** · all four macOS artifacts + three Linux bundles built and verified · onboarding + cask gating screenshot-verified on the VM

## Release plan

**Holding the release until Saturday morning.** Proposed versions: Tauri 0.5.2 + native 0.1.1 (not yet bumped). Release-time steps documented in `memory-bank/tasks/2026-06/13-intel-builds-onboarding-linux.md`: per-arch cask body, the dev-host prime-first build recipe (`MACOSX_DEPLOYMENT_TARGET` proc-macro taint forensics), and the Linux-artifacts-ship-manual-first decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)