### PR TITLE
fix: version-wrap + native release tooling (post-0.6.0)

### DIFF
--- a/docs/release-notes/0.6.0.md
+++ b/docs/release-notes/0.6.0.md
@@ -1,0 +1,37 @@
+# brew-browser 0.6.0 / Brew Browser native 0.2.0 — feature-request batch
+
+Signed + notarized release. Tauri is the macOS 13+ / Linux build; native is the
+macOS 26 SwiftUI build. The two version numbers track the same feature batch
+(native 0.2.0 ≙ Tauri 0.6.0); they differ only because each shell versions by
+its own release history.
+
+## What's new
+
+- **Reverse dependencies in package detail.** Package pages show which installed
+  packages require the selected formula ("Required by").
+- **Deprecated / disabled indicators.** Rows and detail panels surface Homebrew's
+  deprecation and disablement metadata — with the upstream reason and any
+  replacement token — instead of hiding lifecycle state.
+- **Manual vs Dependency Library filters.** Library filtering separates packages
+  the user requested from formulae installed only as dependencies.
+- **Per-package disk size.** Package detail shows the on-disk Cellar/Caskroom
+  footprint for installed packages.
+- **Discover sub-categories.** Within a selected Discover category, members are
+  grouped by their co-assigned categories so broad buckets are easier to scan.
+- **Friendlier failure notices.** When a brew job fails, the Activity drawer now
+  shows a concise, actionable notice instead of a raw error code. Casks that
+  need an administrator password (e.g. `docker-desktop`) — which can't prompt
+  under brew-browser's non-interactive brew — now explain to run the upgrade in
+  Terminal, and name the cask.
+
+## Changes
+
+- The Dashboard "Recent changes" card has been withdrawn for this release while
+  its presentation is reworked; it will return in a follow-up. No data is lost —
+  the full history remains in the Activity view.
+- Package metadata and docs aligned to the release train: Tauri `0.6.0`,
+  native `0.2.0`.
+
+## Acknowledgments
+
+- The Reddit feature-request feedback that shaped this batch.

--- a/native/Sources/BrewBrowserKit/DashboardView.swift
+++ b/native/Sources/BrewBrowserKit/DashboardView.swift
@@ -241,6 +241,11 @@ struct UpdatesCard: View {
                             // Version column — fixed width, right-aligned.
                             Text("\(p.installedVersion) → \(p.currentVersion)")
                                 .font(.callout).foregroundStyle(.secondary).monospaced()
+                                // Keep the "old → new" pair on one line; scale down
+                                // to fit rather than wrap/truncate long cask versions
+                                // (e.g. docker-desktop's "4.77.0,228796"). Parity with
+                                // the Tauri Dashboard's white-space:nowrap.
+                                .lineLimit(1).minimumScaleFactor(0.7)
                                 .frame(width: 200, alignment: .trailing)
                         }
                         .contentShape(.rect)

--- a/native/build-app.sh
+++ b/native/build-app.sh
@@ -59,9 +59,13 @@ for b in "$BINDIR"/*.bundle; do
   bname="$(basename "$b")"
   dest="$APP/Contents/Resources/$bname"
   cp -R "$b" "$dest"
-  # Synthesize a minimal Info.plist if SwiftPM didn't emit one, so codesign
-  # treats it as a real bundle.
-  if [ ! -f "$dest/Info.plist" ]; then
+  # Synthesize a minimal Info.plist ONLY when SwiftPM emitted a flat bundle
+  # with no Info.plist anywhere. Newer toolchains (Xcode 27) emit a structured
+  # bundle (Contents/Info.plist + Contents/Resources/…); adding a second
+  # Info.plist at the bundle root there produces a hybrid that codesign
+  # --deep --strict rejects ("unsealed contents present in the bundle root").
+  # So skip synthesis when either a root OR a Contents/ Info.plist exists.
+  if [ ! -f "$dest/Info.plist" ] && [ ! -f "$dest/Contents/Info.plist" ]; then
     # bundle id: strip .bundle, lowercase — e.g. com.zerologic.brew-browser-native.BrewBrowser_BrewBrowserKit
     bid="com.zerologic.brew-browser-native.${bname%.bundle}"
     cat > "$dest/Info.plist" <<PLIST

--- a/native/release.sh
+++ b/native/release.sh
@@ -41,7 +41,13 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 cd "$HERE"
 
 : "${DEVELOPER_ID_APP:?set DEVELOPER_ID_APP to your 'Developer ID Application: …' identity}"
-: "${NOTARY_PROFILE:?set NOTARY_PROFILE to your notarytool keychain profile (see header)}"
+# Notarization credentials: reuse the same Apple ID / app-specific password /
+# team ID that the Tauri build uses (from ~/.config/brew-browser/signing.env),
+# rather than a separate notarytool keychain profile. Either works; this keeps
+# one credential source for both shells.
+: "${APPLE_ID:?set APPLE_ID (source ~/.config/brew-browser/signing.env)}"
+: "${APPLE_PASSWORD:?set APPLE_PASSWORD (app-specific pw; source signing.env)}"
+: "${APPLE_TEAM_ID:?set APPLE_TEAM_ID (source signing.env)}"
 DOWNLOAD_URL_PREFIX="${DOWNLOAD_URL_PREFIX:-https://brew-browser.zerologic.com/native/}"
 OUT_DIR="${OUT_DIR:-$HERE/dist}"
 
@@ -95,7 +101,7 @@ for arch in "${ARCHES[@]}"; do
   ditto -c -k --keepParent "$APP" "$ZIP"
 
   echo "==> [$arch] notarize (waits for Apple)"
-  xcrun notarytool submit "$ZIP" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun notarytool submit "$ZIP" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
   echo "==> [$arch] staple"
   xcrun stapler staple "$APP"
   rm -f "$ZIP"                     # re-zip so the download carries the ticket
@@ -106,12 +112,40 @@ for arch in "${ARCHES[@]}"; do
   cp -R "$APP" "$WORK/$arch/BrewBrowser.app"
 done
 
+# Defensive: relocate any stray .dmg sitting in $OUT_DIR's root into $DMG_DIR
+# before scanning. generate_appcast treats a .dmg and a .zip of the SAME bundle
+# version as duplicate updates and aborts (SUSparkleErrorDomain 1002). Legacy
+# releases (e.g. 0.1.0) left their .dmg in $OUT_DIR root, which collides with
+# that version's .zip on the next run. The current convention keeps dmgs in
+# $DMG_DIR (never scanned); sweep any old ones there too so the scan is clean.
+shopt -s nullglob
+for stray in "$OUT_DIR"/*.dmg; do
+  echo "==> moving stray dmg out of appcast scan dir: $(basename "$stray") -> dmg/"
+  mv "$stray" "$DMG_DIR/"
+done
+
+# Sparkle's generate_appcast (current tooling) treats two archives that share a
+# CFBundleVersion as DUPLICATE updates and aborts (SUSparkleErrorDomain 1002) —
+# it does NOT coexist same-version arches in one feed via hardwareRequirements.
+# Apple Silicon is the primary platform and Intel macOS is sunsetting (macOS 28
+# drops Rosetta), so the Sparkle AUTO-UPDATE feed is arm64-only: sideline any
+# non-arm64 (x86_64) zip out of the scan dir before generating. Both arches'
+# .dmgs are still built below for FIRST-INSTALL download — only the auto-update
+# feed is arm64. (If Intel auto-update is ever needed: dual per-arch feeds with
+# a per-arch SUFeedURL baked into Info.plist — see git history of this script.)
+SIDELINE_DIR="$OUT_DIR/no-feed"
+mkdir -p "$SIDELINE_DIR"
+for nonarm in "$OUT_DIR"/*-x86_64.zip; do
+  echo "==> sidelining non-arm64 zip from arm64 feed: $(basename "$nonarm") -> no-feed/"
+  mv "$nonarm" "$SIDELINE_DIR/"
+done
+shopt -u nullglob
+
 # generate_appcast runs ONCE over $OUT_DIR, which at this point holds ONLY the
-# .zips (this release's two arches + prior releases' history) — the dmgs don't
-# exist yet and land in $DMG_DIR, which it never scans. Sparkle emits
-# sparkle:hardwareRequirements per archive, which is how two same-version items
-# (one per arch) coexist in one feed (the 0.1.0 appcast demonstrated this).
-echo "==> generate appcast (signs with the Sparkle private key in your Keychain)"
+# arm64 .zips (this release + prior arm64 history) — non-arm64 zips were
+# sidelined above, and the dmgs don't exist yet (they land in $DMG_DIR, which
+# generate_appcast never scans).
+echo "==> generate appcast (arm64 feed; signs with the Sparkle private key in your Keychain)"
 "$SPARKLE_BIN/generate_appcast" --download-url-prefix "$DOWNLOAD_URL_PREFIX" "$OUT_DIR"
 
 # Disk images for FIRST-INSTALL download (humans prefer a .dmg; Sparkle uses the
@@ -129,31 +163,28 @@ for arch in "${ARCHES[@]}"; do
   hdiutil create -volname "Brew Browser" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
   codesign --force --timestamp --sign "$DEVELOPER_ID_APP" "$DMG"
   echo "==> [$arch] notarize dmg (waits for Apple)"
-  xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun notarytool submit "$DMG" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
   xcrun stapler staple "$DMG"
 done
 
-# Post-run sanity: the appcast must carry ONE item per arch for this version,
-# each with sparkle:hardwareRequirements — that's how a single feed serves both
-# arches. Counted here so a bad feed never ships silently.
+# Post-run sanity: the auto-update feed is arm64-only (Intel macOS is sunsetting
+# and Sparkle won't coexist same-version arches in one feed), so the appcast
+# must carry exactly the arm64 enclosure for this version. Counted here so a
+# bad/empty feed never ships silently.
 APPCAST="$OUT_DIR/appcast.xml"
-ITEM_COUNT="$(grep -c "BrewBrowser-$VERSION-" "$APPCAST" 2>/dev/null || true)"
-HW_COUNT="$(grep -c "sparkle:hardwareRequirements" "$APPCAST" 2>/dev/null || true)"
+ITEM_COUNT="$(grep -c "BrewBrowser-$VERSION-arm64.zip" "$APPCAST" 2>/dev/null || true)"
 
 echo
 echo "==> done."
 echo "   Post-run checklist:"
-echo "   [ ] appcast.xml has one <item> per arch for $VERSION (found $ITEM_COUNT enclosure(s) matching BrewBrowser-$VERSION-<arch>.zip)"
-echo "   [ ] each item carries sparkle:hardwareRequirements (found $HW_COUNT in the feed)"
-echo "   [ ] spot-check: grep -A3 \"BrewBrowser-$VERSION-\" \"$APPCAST\""
-if [ "${ITEM_COUNT:-0}" -lt 2 ] || [ "${HW_COUNT:-0}" -lt 2 ]; then
+echo "   [ ] appcast.xml advertises the arm64 build of $VERSION (found $ITEM_COUNT arm64 enclosure(s))"
+echo "   [ ] spot-check: grep -A3 \"BrewBrowser-$VERSION-arm64.zip\" \"$APPCAST\""
+if [ "${ITEM_COUNT:-0}" -lt 1 ]; then
   echo
   echo "   ############################################################################"
-  echo "   ## WARNING: appcast.xml does NOT look right for a dual-arch release.      ##"
-  echo "   ## generate_appcast may have collapsed/dropped the two same-version zips. ##"
-  echo "   ## FALLBACK PLAN: dual feeds — generate appcast-arm64.xml and             ##"
-  echo "   ## appcast-x86_64.xml from per-arch zip dirs, and have build-app.sh bake  ##"
-  echo "   ## a per-arch SUFeedURL into Info.plist. Do NOT ship this appcast as-is.  ##"
+  echo "   ## WARNING: appcast.xml does NOT advertise the arm64 build of $VERSION.    "
+  echo "   ## generate_appcast may have failed or the arm64 zip was missing/sidelined.##"
+  echo "   ## Do NOT ship this appcast as-is — investigate before publishing.        ##"
   echo "   ############################################################################"
 fi
 echo

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -1234,7 +1234,11 @@
   .outdated-row.selected .o-version { color: inherit; }
   .outdated-list li:last-child .outdated-row { border-bottom: none; }
   .o-name { font-weight: var(--fw-medium); }
-  .o-version { font-size: var(--text-body-sm); }
+  /* Keep the "old → new" version pair on one line — never break between a
+     version and its arrow. The name column (minmax(0,1fr) + .truncate) absorbs
+     any width pressure instead, so long cask versions (e.g. docker-desktop's
+     "4.77.0,228796") stay readable as a single row. */
+  .o-version { font-size: var(--text-body-sm); white-space: nowrap; }
 
   /* ─── Split ───────────────────────────────────────────── */
   .split { padding: var(--space-4); display: flex; flex-direction: column; gap: var(--space-3); }


### PR DESCRIPTION
## Summary

Post-release follow-up to **v0.6.0 / native 0.2.0** (already shipped). These are the source fixes made while cutting that release — the built artifacts already include them; this lands them in the repo.

### Fixes
- **Updates-card version wrap** (both shells): long cask versions like docker-desktop's `4.65.0,221669 → 4.77.0,228796` no longer break mid-pair. Tauri uses `white-space:nowrap` (name column absorbs width); native uses `lineLimit(1)` + `minimumScaleFactor(0.7)`.
- **Native build/release tooling** (surfaced building 0.2.0 on Xcode 27):
  - `build-app.sh`: newer SwiftPM emits **structured** resource bundles (`Contents/Info.plist`); the old flat-bundle `Info.plist` synthesis produced a hybrid that `codesign --deep --strict` rejected. Now only synthesizes for genuinely flat bundles.
  - `release.sh`: notarize with the shared Apple creds (no separate notarytool profile); sweep stray `.dmg`s out of the appcast scan dir (legacy `0.1.0.dmg` collided as a duplicate version); generate the Sparkle feed **arm64-only** (`generate_appcast` rejects two same-version arch zips; Intel macOS is sunsetting). Both-arch dmgs still ship for first-install.

### Docs
- `0.6.0.md` release notes.

## Not in this PR
- Recent Changes Dashboard card restore + version-format display polish — deferred to the 0.x.1 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
