### PR TITLE
fix(#80): make brew cleanup --scrub opt-in (default off)

### DIFF
--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -1310,13 +1310,16 @@ public final class AppModel {
         doctorRunning = false
     }
 
-    /// `brew cleanup --prune=all --scrub [--verbose]` as a streaming Activity
+    /// `brew cleanup --prune=all [--scrub] [--verbose]` as a streaming Activity
     /// job (#80). Destructive of cached downloads only — the UI confirm-gates it.
-    /// On success, re-measures the Storage card so the smaller cache is shown.
-    func runCleanup(verbose: Bool) async {
+    /// `scrub` is opt-in (default off in the UI): it also removes the latest
+    /// versions' downloads, so it's a deliberate toggle. On success, re-measures
+    /// the Storage card so the smaller cache is shown.
+    func runCleanup(scrub: Bool, verbose: Bool) async {
         guard !maintenanceBusy else { return }
         cleanupRunning = true
-        var args = ["cleanup", "--prune=all", "--scrub"]
+        var args = ["cleanup", "--prune=all"]
+        if scrub { args.append("--scrub") }
         if verbose { args.append("--verbose") }
         let ok = await startJob("Cleaning up Homebrew cache", args: args, startedAt: Date().timeIntervalSince1970)
         cleanupRunning = false

--- a/native/Sources/BrewBrowserKit/DashboardView.swift
+++ b/native/Sources/BrewBrowserKit/DashboardView.swift
@@ -502,9 +502,10 @@ struct CategoriesCard: View {
 struct StorageCard: View {
     @Bindable var model: AppModel
 
-    // Issue #80 — cache cleanup confirm gate + verbose preference (local UI state).
+    // Issue #80 — cache cleanup confirm gate + toggles (local UI state).
     @State private var showCleanupConfirm = false
     @State private var cleanupVerbose = true
+    @State private var cleanupScrub = false  // opt-in: also remove latest-version downloads
 
     private func human(_ bytes: Int64) -> String {
         let gb = Double(bytes) / 1_073_741_824
@@ -584,6 +585,8 @@ struct StorageCard: View {
                         Text(cleanupConfirmText)
                             .font(.callout).foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
+                        Toggle("Scrub — also remove the latest versions' cached downloads (more aggressive)", isOn: $cleanupScrub)
+                            .font(.callout)
                         Toggle("Verbose — list every file removed", isOn: $cleanupVerbose)
                             .font(.callout)
                         HStack {
@@ -591,7 +594,7 @@ struct StorageCard: View {
                             Button("Cancel") { showCleanupConfirm = false }
                             Button("Clean up", role: .destructive) {
                                 showCleanupConfirm = false
-                                Task { await model.runCleanup(verbose: cleanupVerbose) }
+                                Task { await model.runCleanup(scrub: cleanupScrub, verbose: cleanupVerbose) }
                             }
                         }
                     }
@@ -613,8 +616,11 @@ struct StorageCard: View {
         } else {
             freeing = ""
         }
-        return "Removes cached downloads\(freeing) — including the current versions "
-            + "(--scrub). Your installed packages are not affected."
+        let scrubNote = cleanupScrub
+            ? " Also clears the current versions' downloads (--scrub)."
+            : ""
+        return "Removes outdated cached downloads\(freeing).\(scrubNote) "
+            + "Your installed packages are not affected."
     }
 }
 

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -207,30 +207,32 @@ pub async fn brew_doctor_stream(
     run_brew_streaming(&path, args, display, on_event, jobs).await
 }
 
-/// `brew cleanup --prune=all --scrub [--verbose]` — reclaim cache space (issue
-/// #80). Destructive of CACHED DOWNLOADS only (incl. current versions, via
-/// `--scrub`); installed packages are untouched. The UI confirm-gates this with
-/// the reclaimable estimate (see `brew_cleanup_preview`). `verbose` mirrors the
-/// reporter's preference to see every file removed. On success the disk-usage
-/// cache is dropped so the Storage card re-measures the now-smaller cache.
+/// `brew cleanup --prune=all [--scrub] [--verbose]` — reclaim cache space (issue
+/// #80). Destructive of CACHED DOWNLOADS only; installed packages are untouched.
+/// `scrub` (opt-in, default off in the UI) also removes the LATEST versions'
+/// downloads — more aggressive, so it's a deliberate toggle rather than the
+/// default. `verbose` lists every file removed. The UI confirm-gates this with
+/// the reclaimable estimate (see `brew_cleanup_preview`). On success the
+/// disk-usage cache is dropped so the Storage card re-measures.
 #[tauri::command]
 pub async fn brew_cleanup(
+    scrub: bool,
     verbose: bool,
     on_event: Channel<BrewStreamEvent>,
     state: State<'_, AppState>,
 ) -> Result<JobResult, BrewError> {
     let path = state.require_brew_path().await?;
 
-    let mut args = vec![
-        "cleanup".to_string(),
-        "--prune=all".to_string(),
-        "--scrub".to_string(),
-    ];
+    let mut args = vec!["cleanup".to_string(), "--prune=all".to_string()];
+    if scrub {
+        args.push("--scrub".to_string());
+    }
     if verbose {
         args.push("--verbose".to_string());
     }
     let display = format!(
-        "brew cleanup --prune=all --scrub{}",
+        "brew cleanup --prune=all{}{}",
+        if scrub { " --scrub" } else { "" },
         if verbose { " --verbose" } else { "" }
     );
     let jobs = state.jobs.clone();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -233,13 +233,16 @@ export function brewDoctorStream(
   });
 }
 
-/** Issue #80 — stream `brew cleanup --prune=all --scrub [--verbose]`. The
- *  caller MUST confirm first (destructive of cached downloads). */
+/** Issue #80 — stream `brew cleanup --prune=all [--scrub] [--verbose]`. The
+ *  caller MUST confirm first (destructive of cached downloads). `scrub` is
+ *  opt-in (default off) — it also removes the latest versions' downloads. */
 export function brewCleanup(
+  scrub: boolean,
   verbose: boolean,
   onEvent: (evt: BrewStreamEvent) => void,
 ): Promise<JobResult> {
   return invoke<JobResult>("brew_cleanup", {
+    scrub,
     verbose,
     onEvent: makeChannel(onEvent),
   });

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -50,6 +50,7 @@
   let cleanupRunning = $state(false);
   let cleanupConfirmOpen = $state(false);
   let cleanupVerbose = $state(true); // reporter likes seeing every file removed
+  let cleanupScrub = $state(false);  // opt-in: also remove latest-version downloads
   let maintBusy = $derived(doctorRunning || cleanupRunning);
 
   async function loadDisk(force = false) {
@@ -113,8 +114,8 @@
     try {
       const ok = await streamJob(
         "Cleaning up Homebrew cache",
-        "brew cleanup --prune=all --scrub",
-        (onEvent) => brewCleanup(cleanupVerbose, onEvent),
+        `brew cleanup --prune=all${cleanupScrub ? " --scrub" : ""}${cleanupVerbose ? " --verbose" : ""}`,
+        (onEvent) => brewCleanup(cleanupScrub, cleanupVerbose, onEvent),
       );
       if (ok) {
         // Cache shrank — re-measure the Storage card + refresh the estimate.
@@ -1001,7 +1002,7 @@
               variant="ghost"
               onclick={() => (cleanupConfirmOpen = !cleanupConfirmOpen)}
               disabled={maintBusy}
-              title="Reclaim cached downloads (brew cleanup --prune=all --scrub)"
+              title="Reclaim cached downloads (brew cleanup --prune=all)"
             >
               {#snippet icon()}<Trash2 size={14} />{/snippet}
               {cleanupRunning ? "Cleaning…" : "Clean up cache…"}
@@ -1014,10 +1015,15 @@
           {#if cleanupConfirmOpen}
             <div class="maint-confirm" role="group" aria-label="Confirm cache cleanup">
               <p>
-                Removes cached downloads{#if cleanupPreview?.reclaimableBytes}, freeing about
-                <strong>{fmtBytes(cleanupPreview.reclaimableBytes)}</strong>{/if} — including the
-                current versions (<code>--scrub</code>). Your installed packages are not affected.
+                Removes outdated cached downloads{#if cleanupPreview?.reclaimableBytes}, freeing about
+                <strong>{fmtBytes(cleanupPreview.reclaimableBytes)}</strong>{/if}.{#if cleanupScrub}
+                Also clears the <strong>current</strong> versions' downloads (<code>--scrub</code>).{/if}
+                Your installed packages are not affected.
               </p>
+              <label class="maint-verbose">
+                <input type="checkbox" bind:checked={cleanupScrub} />
+                Scrub — also remove the latest versions' cached downloads (more aggressive)
+              </label>
               <label class="maint-verbose">
                 <input type="checkbox" bind:checked={cleanupVerbose} />
                 Verbose — list every file removed


### PR DESCRIPTION
Follow-up to #80 / #82, per reporter feedback.

`brew cleanup` now defaults to **`--prune=all`** (no scrub). **`--scrub`** — which also clears the *current* versions' cached downloads — is now an explicit opt-in toggle in the confirm sheet (off by default), above Verbose. Safer default; the power-user option is one click away.

Both shells in parity. The display command and confirm copy adapt to the toggle (the "clears current versions (--scrub)" note only appears when scrub is on).

Tests: cargo 649 · swift build clean · svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)