### PR TITLE
docs: add brew trust step to install instructions (Homebrew 6.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ Both macOS builds ship on the **[latest release](https://github.com/msitarzewski
 
 ```sh
 brew tap msitarzewski/brew-browser
+brew trust msitarzewski/brew-browser   # Homebrew 6.x requires trusting non-official taps
 brew install --cask brew-browser
 ```
 
-Installs the same notarized `.dmg`; update later with `brew upgrade --cask brew-browser`.
+Installs the same notarized `.dmg` (Apple Silicon **or** Intel); update later with `brew upgrade --cask brew-browser`. The `brew trust` line is required on Homebrew 6.0+, which refuses to load casks from non-official taps until you trust them — a one-time step.
 
 ### Tauri build — Linux (newly supported)
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -213,8 +213,9 @@
       </ul>
       <p>Or install with Homebrew:</p>
       <pre><code>brew tap msitarzewski/brew-browser
+brew trust msitarzewski/brew-browser
 brew install --cask brew-browser</code></pre>
-      <p>Installs the same notarized <code>.dmg</code>.</p>
+      <p>Installs the same notarized <code>.dmg</code> (Apple Silicon or Intel). The <code>brew trust</code> step is a one-time requirement on Homebrew 6.0+, which won't load casks from non-official taps until you trust them.</p>
       <p>Or build it yourself from source — the cross-platform <strong>Tauri</strong> build:</p>
       <pre><code>git clone https://github.com/msitarzewski/brew-browser
 cd brew-browser


### PR DESCRIPTION
Homebrew 6.0 enforces tap-trust by default — the 2-line install now fails with 'refusing to load from untrusted tap' until the user runs `brew trust msitarzewski/brew-browser`. Adds the one-time trust step to the README + landing-page install blocks and notes Apple-Silicon-or-Intel support.

Pairs with [homebrew-brew-browser#4](https://github.com/msitarzewski/homebrew-brew-browser/pull/4), which fixes the cask itself (0.6.0, dual-arch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)