### PR TITLE
fix: stop inviting issue reports for upstream brew failures

### DIFF
--- a/native/Sources/BrewBrowserKit/ActivityView.swift
+++ b/native/Sources/BrewBrowserKit/ActivityView.swift
@@ -160,12 +160,27 @@ struct ActivityDrawer: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(AppModel.failureNoticeTitle(for: job.label))
                         .font(.callout.weight(.semibold))
-                    Text(job.friendlyFailureMessage ?? "See the Activity output below for details.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                    if job.friendlyFailureMessage == nil {
+                    if let friendly = job.friendlyFailureMessage {
+                        // Known brew failure with a curated friendly message.
+                        Text(friendly)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else if !AppModel.isAppError(job) {
+                        // brew ran and exited non-zero: a Homebrew/formula problem,
+                        // NOT a brew-browser bug. No report — point at Terminal.
+                        Text("This looks like a Homebrew error, not a brew-browser bug — the command ran but exited with status \(job.exitCode ?? 0). Try the same command in Terminal; if it fails there too, it's a Homebrew or formula issue to report upstream.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        // No brew exit code = the app couldn't run the command. Our bug.
+                        Text("brew-browser hit an unexpected error running this command.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                         Button("Report to brew-browser") {
                             ReportIssue.open(for: job, brewVersion: model.brewVersion)
                         }
@@ -221,7 +236,7 @@ struct ActivityDrawer: View {
                     .font(.caption)
                     .foregroundStyle(Self.footerColor(job.status))
                     .lineLimit(3)
-                if job.status == .failed && job.friendlyFailureMessage == nil {
+                if job.status == .failed && AppModel.isAppError(job) {
                     Button("Report to brew-browser") {
                         ReportIssue.open(for: job, brewVersion: model.brewVersion)
                     }

--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -2111,6 +2111,16 @@ public final class AppModel {
         return "\(label) failed"
     }
 
+    /// True when a failed job is a genuine brew-browser problem (worth a
+    /// "Report to brew-browser") rather than a brew-command failure. A non-zero
+    /// brew exit means the command RAN and failed = a Homebrew/formula problem,
+    /// not our bug — so it is NOT reportable. Only a failure without a real brew
+    /// exit code (the app couldn't run the command) is. Mirrors the Tauri
+    /// drawer's `exitCode == null` check.
+    static func isAppError(_ job: ActivityJob) -> Bool {
+        (job.exitCode ?? 0) == 0
+    }
+
     private func focusFailedJobInDrawer(_ jobId: UUID) {
         activeJobId = jobId
         drawerOpen = true

--- a/src/lib/components/ActivityDrawer.svelte
+++ b/src/lib/components/ActivityDrawer.svelte
@@ -179,7 +179,9 @@
   function failedFooter(job: typeof activeJob): string {
     if (!job) return "Failed.";
     const base = `Failed${job.durationMs ? ` after ${formatElapsed(job.durationMs)}` : ""}.`;
-    return job.friendlyMessage ? `${base} See notice at right.` : `${base} Output above.`;
+    // The failure card on the right always renders a notice now (friendly
+    // message, Homebrew-error guidance, or app-error report), so always point there.
+    return `${base} See the notice at right.`;
   }
 
   function failureTitle(label: string): string {
@@ -285,8 +287,23 @@
               <AlertTriangle size={16} />
               <h3>{failureTitle(activeJob.label)}</h3>
             </div>
-            <p>{activeJob.friendlyMessage ?? "See the Activity output for details."}</p>
-            {#if !activeJob.friendlyMessage}
+            {#if activeJob.friendlyMessage}
+              <!-- A known brew failure with a curated friendly message. -->
+              <p>{activeJob.friendlyMessage}</p>
+            {:else if activeJob.exitCode != null}
+              <!-- brew ran and exited non-zero: a Homebrew/formula problem, NOT a
+                   brew-browser bug. Don't invite a report — point at Terminal so the
+                   real (upstream) failure is taken to the right place. -->
+              <p>
+                This looks like a <strong>Homebrew</strong> error, not a brew-browser bug —
+                the command ran but exited with status {activeJob.exitCode}. Try the same
+                command in Terminal; if it fails there too, it's a Homebrew or formula issue
+                to report upstream.
+              </p>
+            {:else}
+              <!-- No exit code = brew-browser couldn't run the command (IPC/spawn
+                   failure). That IS our bug, so this is the only case that offers a report. -->
+              <p>brew-browser hit an unexpected error running this command.</p>
               <button
                 type="button"
                 class="report-btn"

--- a/src/lib/util/reportIssue.ts
+++ b/src/lib/util/reportIssue.ts
@@ -171,10 +171,20 @@ export function reportContextFromActivityJob(
  */
 export function reportableToastError(title: string, e: unknown): void {
   if (isBrewError(e)) {
-    const ctx = reportContextFromBrewError(e, title);
-    if (e.code === "brew_exit_non_zero" && e.friendlyMessage) {
+    // A brew command that exited non-zero is a Homebrew/formula problem, NOT a
+    // brew-browser bug — never offer "Report to brew-browser" for it (that was
+    // the dominant source of misfiled "[brew-browser] Upgrade-all failed"
+    // issues). Classified failures are already shown in the Activity drawer's
+    // failure card, so skip the toast entirely; unclassified ones get a plain
+    // error toast with NO report action.
+    if (e.code === "brew_exit_non_zero") {
+      if (e.friendlyMessage) return;
+      toast.error(title, brewErrorMessage(e));
       return;
     }
+    // Other BrewError codes (Io, Internal, parse failures, …) are app-side
+    // problems worth reporting.
+    const ctx = reportContextFromBrewError(e, title);
     toast.error(title, brewErrorMessage(e), {
       label: "Report to brew-browser",
       onClick: () => {


### PR DESCRIPTION
## The problem
The repo's 50 open issues are mostly auto-titled `[brew-browser] Upgrade-all failed` / `Uninstall failed` etc. — generated by the in-app **Report to brew-browser** button. But those are **Homebrew/formula failures**, not brew-browser bugs.

The Report button was gated on whether we had a *curated friendly message*, so any **unrecognized** brew failure (the long tail) still showed it.

## The fix — gate on the real signal: did brew actually run?
- **brew ran and exited non-zero** (`exitCode` present) → Homebrew problem. Show *"this is a Homebrew error, try it in Terminal"* guidance, **no report button**.
- **failed with no brew exit code** (IPC/spawn — the app couldn't run it) → genuine app bug → keep **Report to brew-browser**.
- **known friendly-pattern failures** → unchanged (curated message, no report).

Both shells, in parity (Tauri `ActivityDrawer`/`reportIssue.ts`; native `ActivityView` + `AppModel.isAppError`).

svelte-check 0 errors · vitest 35 · swift build clean.

This stops the flood at the source — pairs with triaging/closing the existing 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)