### PR TITLE
fix(catalog): reject empty formulae/casks array from refresh endpoint

### DIFF
--- a/src-tauri/src/commands/catalog.rs
+++ b/src-tauri/src/commands/catalog.rs
@@ -167,6 +167,20 @@ pub(crate) async fn refresh_catalog_inner(state: &AppState) -> Result<CatalogSum
     let formula_count = count_top_level_array(&formula_raw, FORMULA_URL)?;
     let cask_count = count_top_level_array(&cask_raw, CASK_URL)?;
 
+    // Reject an empty response: formulae.brew.sh always returns thousands
+    // of entries. A zero count means the body parsed as JSON but is empty
+    // (a hostile mirror, a partial response, or a CDN error page that
+    // happens to be a JSON array). Persisting it would silently zero out
+    // the user's catalog.
+    if formula_count == 0 || cask_count == 0 {
+        return Err(BrewError::InvalidArgument {
+            message: format!(
+                "catalog response is empty (formulae={}, casks={})",
+                formula_count, cask_count
+            ),
+        });
+    }
+
     // gzip both — this is what we'll persist + what `load_user_data`
     // expects on next launch.
     let formula_gz = gzip_compress(&formula_raw)?;


### PR DESCRIPTION
After `count_top_level_array` succeeds the code previously continued unconditionally and persisted a fresh manifest with `formula_count` or `cask_count` equal to 0. `formulae.brew.sh` always returns thousands of entries on a healthy response, so a zero count is a strong signal that something went wrong upstream: a hostile mirror, a partial body, or a CDN error page that happens to parse as a JSON array.

Persisting such a response would silently zero out the user's catalog on the next launch. This change turns a zero count into a typed error so the caller (UI, auto-refresh helper) keeps the previous good catalog and surfaces a refresh failure to the user.

Non-empty behavior is unchanged; only an empty array short-circuits.
