### PR TITLE
fix: vuln-scan tap names + JSON salvage (#62, #92) and disable Homebrew analytics

### DIFF
--- a/native/Sources/BrewBrowserKit/BrewService.swift
+++ b/native/Sources/BrewBrowserKit/BrewService.swift
@@ -132,6 +132,25 @@ struct BrewService: Sendable {
     /// Run a brew subcommand to completion and return captured stdout.
     /// `current_dir` is pinned to "/" to dodge the "cwd must be readable"
     /// failure the Linux build hit — harmless on macOS, future-proof.
+    /// Environment for every `brew` subprocess this app spawns.
+    ///
+    /// `HOMEBREW_NO_ANALYTICS=1` disables Homebrew's own analytics so our
+    /// automated brew calls never trigger its ping to Homebrew's InfluxDB
+    /// endpoint (`*.influxdata.com`). Brew Browser sends no telemetry, and must
+    /// not cause `brew` to send any on the user's behalf either — a user
+    /// reported the startup `*.influxdata.com` connection, which was Homebrew's,
+    /// fired because we shell out to `brew`. The user's OWN global brew-analytics
+    /// preference (for manual CLI use) is untouched. `NO_COLOR`/`NO_ENV_HINTS`
+    /// keep brew's terminal chatter out of captured/streamed output.
+    /// See https://docs.brew.sh/Analytics.
+    static func brewEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        env["HOMEBREW_NO_ANALYTICS"] = "1"
+        env["HOMEBREW_NO_COLOR"] = "1"
+        env["HOMEBREW_NO_ENV_HINTS"] = "1"
+        return env
+    }
+
     private func runCapture(_ args: [String]) async throws -> String {
         guard let brew = Self.resolveBrewPath() else { throw BrewError.brewNotFound }
 
@@ -139,6 +158,7 @@ struct BrewService: Sendable {
         process.executableURL = URL(fileURLWithPath: brew)
         process.arguments = args
         process.currentDirectoryURL = URL(fileURLWithPath: "/")
+        process.environment = Self.brewEnvironment()
 
         let stdout = Pipe()
         let stderr = Pipe()
@@ -237,11 +257,9 @@ struct BrewService: Sendable {
             process.standardOutput = outPipe
             process.standardError = errPipe
             // Tell brew not to expect a terminal (disables spinners/color that
-            // would otherwise garble the streamed lines).
-            var env = ProcessInfo.processInfo.environment
-            env["HOMEBREW_NO_COLOR"] = "1"
-            env["HOMEBREW_NO_ENV_HINTS"] = "1"
-            process.environment = env
+            // would otherwise garble the streamed lines) and disable Homebrew's
+            // own analytics ping (see brewEnvironment()).
+            process.environment = Self.brewEnvironment()
 
             let outHandle = outPipe.fileHandleForReading
             let errHandle = errPipe.fileHandleForReading

--- a/native/Sources/BrewBrowserKit/VulnsService.swift
+++ b/native/Sources/BrewBrowserKit/VulnsService.swift
@@ -257,7 +257,13 @@ struct VulnsService: Sendable {
         // brew vulns IGNORES --formula and returns the whole install set, so we
         // must keep only the requested formula's record — otherwise the detail
         // card shows every other package's CVEs (boost/icu/jxl/…) under this one.
-        return records.first(where: { $0.formula == name })?.findings ?? []
+        // brew vulns may echo a tap-qualified name under its bare form (or
+        // vice-versa), so match the exact name OR the last `/`-segment (#92).
+        let wantTail = name.split(separator: "/").last.map(String.init) ?? name
+        return records.first(where: {
+            $0.formula == name
+                || $0.formula.split(separator: "/").last.map(String.init) == wantTail
+        })?.findings ?? []
     }
 
     /// Scan the WHOLE install set in ONE `brew vulns --json` call (no
@@ -466,8 +472,33 @@ struct VulnsService: Sendable {
     private static func parseScanOutput(_ raw: String) throws -> [ScanRecord] {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
-        guard let data = trimmed.data(using: .utf8) else { return [] }
 
+        // Fast path: the whole stdout is the JSON document (the common case).
+        if let records = decodeRecords(trimmed) {
+            return records
+        }
+        // Salvage: older brew / brew-vulns can print a banner or notice on
+        // stdout around the `--json` document (issue #62 — `whatcable` on brew
+        // 5.1.15). Slice the JSON document out of the surrounding line-oriented
+        // noise and retry. Mirrors the Rust `extract_json_document`.
+        if let slice = extractJSONDocument(trimmed) {
+            if let records = decodeRecords(slice) {
+                return records
+            }
+            // A JSON-looking payload was present but malformed → surface it.
+            throw VulnsServiceError.decodeFailed("output starts: \(String(trimmed.prefix(400)))")
+        }
+        // No JSON structure at all on a clean exit (already past the exit-≥2
+        // gate in the caller). Treat as "nothing to report" rather than a
+        // scary decode error — consistent with scanAll silently omitting
+        // unsupported-forge formulae (issue #62).
+        return []
+    }
+
+    /// Decode both documented shapes: an array (the norm) then a single object
+    /// (defensive fallback). `nil` if the input isn't valid JSON in either shape.
+    private static func decodeRecords(_ s: String) -> [ScanRecord]? {
+        guard let data = s.data(using: .utf8) else { return nil }
         let decoder = JSONDecoder()
         if let array = try? decoder.decode([ScanRecord].self, from: data) {
             return array
@@ -475,21 +506,56 @@ struct VulnsService: Sendable {
         if let single = try? decoder.decode(ScanRecord.self, from: data) {
             return [single]
         }
-        // Surface a typed decode failure with a bounded excerpt.
-        throw VulnsServiceError.decodeFailed("output starts: \(String(trimmed.prefix(400)))")
+        return nil
+    }
+
+    /// Extract the JSON document from line-oriented CLI noise: from the first
+    /// line that (left-trimmed) starts with `[`/`{` to the last line that
+    /// (right-trimmed) ends with `]`/`}`. Line-granular so a stray bracket in a
+    /// mid-sentence warning doesn't derail extraction. `nil` when no such
+    /// bracketed block exists. Mirrors the Rust `extract_json_document`.
+    static func extractJSONDocument(_ raw: String) -> String? {
+        let lines = raw.components(separatedBy: "\n")
+        let ws = CharacterSet(charactersIn: " \t")
+        guard
+            let start = lines.firstIndex(where: {
+                let t = $0.trimmingCharacters(in: ws)
+                return t.first == "[" || t.first == "{"
+            }),
+            let end = lines.lastIndex(where: {
+                let t = $0.trimmingCharacters(in: ws)
+                return t.last == "]" || t.last == "}"
+            }),
+            start <= end
+        else { return nil }
+        return lines[start...end].joined(separator: "\n")
     }
 
     /// Validate a formula name before passing it to `brew vulns
     /// --formula`. Defense-in-depth against shell-meta injection even
     /// though `Process`/argv is already injection-safe — mirrors the
     /// Rust `validate_formula_name`.
-    private static func validateFormulaName(_ name: String) throws {
+    static func validateFormulaName(_ name: String) throws {
         guard !name.isEmpty, name.count <= 128 else {
             throw VulnsServiceError.invalidFormulaName(name)
         }
+        // Allow `/` so tap-qualified names (`user/repo/name`) pass — brew vulns
+        // accepts them and users scan formulae from third-party taps (issue #92,
+        // `anomalyco/tap/opencode`). Process/argv is injection-safe and the
+        // vulns cache keys names into a map, NOT a path, so `/` adds no risk;
+        // the structure guard below keeps it tight. Mirrors the Rust validator.
         let allowed = CharacterSet(charactersIn:
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_+@.")
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_+@./")
         guard name.unicodeScalars.allSatisfy(allowed.contains) else {
+            throw VulnsServiceError.invalidFormulaName(name)
+        }
+        // A tap-qualified name is exactly `user/repo/name` (2 slashes); a bare
+        // name has none. Reject anything else — empty segments, leading/trailing
+        // slash, `a//b`, `.`/`..` path segments, or deeper paths.
+        let segments = name.split(separator: "/", omittingEmptySubsequences: false)
+        let wellFormed = (segments.count == 1 || segments.count == 3)
+            && segments.allSatisfy { !$0.isEmpty && $0 != "." && $0 != ".." }
+        guard wellFormed else {
             throw VulnsServiceError.invalidFormulaName(name)
         }
     }

--- a/native/Tests/BrewBrowserKitTests/BrewOutputParsingTests.swift
+++ b/native/Tests/BrewBrowserKitTests/BrewOutputParsingTests.swift
@@ -266,3 +266,18 @@ struct DoctorCleanupParsingTests {
         #expect(BrewErrorPatterns.parseReclaimableBytes("") == nil)
     }
 }
+
+@Suite("BrewService.brewEnvironment")
+struct BrewEnvironmentTests {
+    // The privacy contract (parity with Rust `brew::exec::BREW_ENV`): every
+    // app-spawned brew command disables Homebrew's own InfluxDB analytics ping.
+    @Test func disablesHomebrewAnalytics() {
+        #expect(BrewService.brewEnvironment()["HOMEBREW_NO_ANALYTICS"] == "1")
+    }
+
+    @Test func keepsTerminalChatterSuppressed() {
+        let env = BrewService.brewEnvironment()
+        #expect(env["HOMEBREW_NO_COLOR"] == "1")
+        #expect(env["HOMEBREW_NO_ENV_HINTS"] == "1")
+    }
+}

--- a/native/Tests/BrewBrowserKitTests/VulnsParsingTests.swift
+++ b/native/Tests/BrewBrowserKitTests/VulnsParsingTests.swift
@@ -81,9 +81,68 @@ struct VulnsParseTests {
         #expect(try VulnsService.parseScanOutputKeyed("   \n  ").isEmpty)
     }
 
-    @Test func malformedOutputThrows() {
+    @Test func pureProseYieldsNoRecords() throws {
+        // Issue #62: a clean exit with non-JSON prose on stdout (e.g. an
+        // unsupported-source notice) is "nothing to report", not an error.
+        #expect(try VulnsService.parseScanOutputKeyed("whatcable: skipped\n").isEmpty)
+        #expect(try VulnsService.parseScanOutputKeyed("this is not json").isEmpty)
+    }
+
+    @Test func salvagesJSONBehindLeadingNoise() throws {
+        // Issue #62: a brew banner/notice on stdout before the --json document.
+        let raw = """
+        Warning: some brew notice
+        [ { "formula": "curl", "version": "8.4.0", "vulnerabilities": [] } ]
+        """
+        let out = try VulnsService.parseScanOutputKeyed(raw)
+        #expect(out["curl"] != nil)
+        #expect(out["curl"]?.isEmpty == true)
+    }
+
+    @Test func salvagesJSONBetweenNoiseLines() throws {
+        let raw = """
+        ==> downloading advisories
+        [ { "formula": "openssl@3", "version": "3.2.0", "vulnerabilities": [] } ]
+        ==> done
+        """
+        let out = try VulnsService.parseScanOutputKeyed(raw)
+        #expect(out["openssl@3"] != nil)
+    }
+
+    @Test func malformedJSONPayloadThrows() {
+        // A bracketed-but-broken payload is a genuine problem, still surfaced.
         #expect(throws: (any Error).self) {
-            _ = try VulnsService.parseScanOutputKeyed("this is not json")
+            _ = try VulnsService.parseScanOutputKeyed("notice\n[ {broken json ]\n")
+        }
+    }
+
+    @Test func extractJSONDocumentSkipsSurroundingLines() {
+        #expect(VulnsService.extractJSONDocument("lead\n  [1,2,3]  \ntrail") == "  [1,2,3]  ")
+        #expect(VulnsService.extractJSONDocument("no json here") == nil)
+    }
+}
+
+@Suite("VulnsService.validateFormulaName")
+struct VulnsValidateNameTests {
+    @Test func acceptsTypicalAndTapQualifiedNames() throws {
+        for name in [
+            "curl", "openssl@3", "python@3.12", "git-lfs", "lib_foo",
+            // Issue #92: third-party tap formulae are `user/repo/name`.
+            "anomalyco/tap/opencode", "homebrew/core/wget", "user-name/repo_2/formula@1.2",
+        ] {
+            try VulnsService.validateFormulaName(name)  // throws on reject
+        }
+    }
+
+    @Test func rejectsMalformedSlashesAndShellMeta() {
+        for bad in [
+            "/leading", "trailing/", "a//b", "two/segments", "a/b/c/d",
+            "a/../b", "../etc/passwd", "./relative",
+            "curl; rm -rf /", "curl|nc", "curl`whoami`", "curl $(id)", "",
+        ] {
+            #expect(throws: (any Error).self, "should reject: \(bad)") {
+                try VulnsService.validateFormulaName(bad)
+            }
         }
     }
 }

--- a/src-tauri/src/brew/exec.rs
+++ b/src-tauri/src/brew/exec.rs
@@ -53,6 +53,26 @@ pub type JobsMap = Arc<Mutex<HashMap<Uuid, JobHandle>>>;
 /// the readable-cwd error, surfacing as "Couldn't load packages."
 const BREW_SPAWN_CWD: &str = "/";
 
+/// Environment overrides applied to EVERY `brew` subprocess this app spawns.
+///
+/// `HOMEBREW_NO_ANALYTICS=1` disables Homebrew's own analytics so our
+/// automated brew calls never trigger its ping to Homebrew's InfluxDB
+/// endpoint (`*.influxdata.com`). Brew Browser itself sends no telemetry, and
+/// it must not cause `brew` to send any on the user's behalf either — a user
+/// reported the startup `*.influxdata.com` connection, which was Homebrew's,
+/// fired because we shell out to `brew`. The user's OWN global brew-analytics
+/// preference (for their manual CLI use) is untouched; this only scopes the
+/// commands WE spawn. See https://docs.brew.sh/Analytics.
+pub(crate) const BREW_ENV: &[(&str, &str)] = &[("HOMEBREW_NO_ANALYTICS", "1")];
+
+/// Apply [`BREW_ENV`] to a brew command. Call at every spawn site so no
+/// `brew` invocation can leak past the analytics-off policy.
+pub(crate) fn apply_brew_env(cmd: &mut Command) {
+    for (key, val) in BREW_ENV {
+        cmd.env(key, val);
+    }
+}
+
 pub async fn run_brew_capture(
     brew_path: &Path,
     args: &[&str],
@@ -65,6 +85,7 @@ pub async fn run_brew_capture(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    apply_brew_env(&mut cmd);
 
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
@@ -123,6 +144,7 @@ pub async fn run_brew_streaming(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    apply_brew_env(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -501,6 +523,16 @@ impl StderrRing {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn brew_env_disables_homebrew_analytics() {
+        // The privacy contract: every app-spawned brew command must carry
+        // HOMEBREW_NO_ANALYTICS=1 so we never trigger brew's InfluxDB ping.
+        assert!(
+            BREW_ENV.contains(&("HOMEBREW_NO_ANALYTICS", "1")),
+            "brew spawn env must disable Homebrew analytics"
+        );
+    }
 
     #[test]
     fn stderr_ring_keeps_lines_under_cap() {

--- a/src-tauri/src/vulns/client.rs
+++ b/src-tauri/src/vulns/client.rs
@@ -303,8 +303,14 @@ pub async fn scan_all(brew: &Path) -> Result<Vec<RawScanResult>, BrewError> {
     // structured output mode brew-vulns supports for CI consumption.
     // Uses the tolerant wrapper because brew-vulns exits 1 on
     // "findings present" (CI-scanner convention) and we want the JSON.
-    let raw = run_vulns_capture(brew, &["vulns", "--json"], "brew vulns --json").await?;
-    parse_scan_output(&raw, "brew vulns --json")
+    // `--quiet` suppresses brew's own progress/banner chatter so it can't land
+    // on stdout and break JSON parsing (parity with the native scanner, and
+    // belt-and-suspenders for issue #62). parse_scan_output also salvages JSON
+    // from any residual noise.
+    let raw =
+        run_vulns_capture(brew, &["vulns", "--quiet", "--json"], "brew vulns --quiet --json")
+            .await?;
+    parse_scan_output(&raw, "brew vulns --quiet --json")
 }
 
 /// Scan a single formula by name. Used by the PackageDetail
@@ -312,16 +318,25 @@ pub async fn scan_all(brew: &Path) -> Result<Vec<RawScanResult>, BrewError> {
 /// [`RawVuln`] list since the caller already knows the formula name.
 pub async fn scan_one(brew: &Path, formula: &str) -> Result<Vec<RawVuln>, BrewError> {
     validate_formula_name(formula)?;
-    let display = format!("brew vulns --json --formula {formula}");
+    let display = format!("brew vulns --quiet --json --formula {formula}");
     // Tolerant wrapper — same exit-1-is-findings semantics as scan_all.
-    let raw = run_vulns_capture(brew, &["vulns", "--json", "--formula", formula], &display).await?;
+    // `--quiet` parity with scan_all (issue #62).
+    let raw = run_vulns_capture(
+        brew,
+        &["vulns", "--quiet", "--json", "--formula", formula],
+        &display,
+    )
+    .await?;
     let results = parse_scan_output(&raw, &display)?;
     // brew vulns IGNORES --formula and returns the WHOLE install set, so keep
     // only the requested formula's record — otherwise the detail card shows
-    // every other package's CVEs (boost/icu/jxl/…) under this one.
+    // every other package's CVEs (boost/icu/jxl/…) under this one. brew vulns
+    // may echo a tap-qualified name under its bare form (or vice-versa), so
+    // match the exact name OR the last `/`-segment (issue #92).
+    let want_tail = formula.rsplit('/').next().unwrap_or(formula);
     Ok(results
         .into_iter()
-        .find(|r| r.formula == formula)
+        .find(|r| r.formula == formula || r.formula.rsplit('/').next() == Some(want_tail))
         .map(|r| r.vulnerabilities)
         .unwrap_or_default())
 }
@@ -356,19 +371,63 @@ fn parse_scan_output(raw: &str, display_command: &str) -> Result<Vec<RawScanResu
     if raw.trim().is_empty() {
         return Ok(Vec::new());
     }
-    // Try array first (the documented shape).
-    if let Ok(arr) = serde_json::from_str::<Vec<RawScanResult>>(raw) {
-        return Ok(arr);
+    // Fast path: the whole stdout is the JSON document (the common case).
+    if let Some(parsed) = try_parse_records(raw) {
+        return Ok(parsed);
     }
-    // Fall back to single object.
-    match serde_json::from_str::<RawScanResult>(raw) {
-        Ok(one) => Ok(vec![one]),
-        Err(e) => Err(BrewError::JsonParse {
+    // Salvage: older brew / brew-vulns versions can print a banner or notice
+    // on stdout around the `--json` document (issue #62 — `whatcable` on brew
+    // 5.1.15 produced "expected value at line 1 column 1"). Slice the JSON
+    // document out of the surrounding line-oriented noise and retry.
+    if let Some(slice) = extract_json_document(raw) {
+        if let Some(parsed) = try_parse_records(&slice) {
+            return Ok(parsed);
+        }
+        // A JSON-looking payload was present but malformed → a genuine
+        // problem worth surfacing (keeps the garbage-input contract).
+        return Err(BrewError::JsonParse {
             command: display_command.to_string(),
-            message: format!("vulns parse: {e}"),
+            message: "vulns parse: could not parse JSON document in output".to_string(),
             raw_excerpt: raw.chars().take(400).collect(),
-        }),
+        });
     }
+    // No JSON structure at all on a clean exit (run_vulns_capture already
+    // surfaced exit ≥2 as an error before we got here). Treat as "nothing to
+    // report" — consistent with scan_all silently omitting unsupported-forge
+    // formulae — rather than a scary parse error in the user's face.
+    Ok(Vec::new())
+}
+
+/// Try both documented shapes: an array (the norm) then a single object
+/// (defensive fallback). `None` if the input isn't valid JSON in either shape.
+fn try_parse_records(s: &str) -> Option<Vec<RawScanResult>> {
+    if let Ok(arr) = serde_json::from_str::<Vec<RawScanResult>>(s) {
+        return Some(arr);
+    }
+    serde_json::from_str::<RawScanResult>(s)
+        .ok()
+        .map(|one| vec![one])
+}
+
+/// Extract the JSON document from line-oriented CLI noise: from the first
+/// line that (left-trimmed) starts with `[`/`{` to the last line that
+/// (right-trimmed) ends with `]`/`}`. Line-granular so a stray bracket in a
+/// mid-sentence warning doesn't derail extraction. `None` when no such
+/// bracketed block exists (pure prose → caller treats as "no results").
+fn extract_json_document(raw: &str) -> Option<String> {
+    let lines: Vec<&str> = raw.lines().collect();
+    let start = lines.iter().position(|l| {
+        let t = l.trim_start();
+        t.starts_with('[') || t.starts_with('{')
+    })?;
+    let end = lines.iter().rposition(|l| {
+        let t = l.trim_end();
+        t.ends_with(']') || t.ends_with('}')
+    })?;
+    if start > end {
+        return None;
+    }
+    Some(lines[start..=end].join("\n"))
 }
 
 /// Validate a brew formula name before passing it to `brew vulns
@@ -383,10 +442,27 @@ pub fn validate_formula_name(name: &str) -> Result<(), BrewError> {
             message: format!("invalid formula name length: {}", name.len()),
         });
     }
+    // Allow `/` so tap-qualified names (`user/repo/name`) pass — brew vulns
+    // accepts them and users scan formulae from third-party taps (issue #92,
+    // `anomalyco/tap/opencode`). `Command::arg` is argv-safe (no shell) and the
+    // vulns cache keys names into a JSON map string, NOT a filesystem path
+    // (see vulns/cache.rs), so `/` introduces no injection/traversal risk; the
+    // structure guard below keeps the surface tight.
     let ok = name
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '+' | '@' | '.'));
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '+' | '@' | '.' | '/'));
     if !ok {
+        return Err(BrewError::InvalidArgument {
+            message: format!("invalid character(s) in formula name: {name}"),
+        });
+    }
+    // A tap-qualified name is exactly `user/repo/name` (2 slashes); a bare name
+    // has none. Reject anything else — empty segments, leading/trailing slash,
+    // `a//b`, `.`/`..` path segments, or deeper paths.
+    let segments: Vec<&str> = name.split('/').collect();
+    let well_formed = matches!(segments.len(), 1 | 3)
+        && segments.iter().all(|s| !s.is_empty() && *s != "." && *s != "..");
+    if !well_formed {
         return Err(BrewError::InvalidArgument {
             message: format!("invalid character(s) in formula name: {name}"),
         });
@@ -566,6 +642,50 @@ mod tests {
         }
     }
 
+    #[test]
+    fn parse_scan_output_salvages_json_behind_leading_noise() {
+        // Issue #62: a brew banner/notice on stdout before the --json document.
+        let raw = "Warning: some brew notice\n[{\"formula\":\"curl\",\"version\":\"8.4.0\",\"vulnerabilities\":[]}]";
+        let parsed = parse_scan_output(raw, "brew vulns --quiet --json").expect("salvaged");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].formula, "curl");
+    }
+
+    #[test]
+    fn parse_scan_output_salvages_json_between_noise_lines() {
+        let raw = "==> downloading advisories\n[{\"formula\":\"openssl@3\",\"version\":\"3.2.0\",\"vulnerabilities\":[]}]\n==> done";
+        let parsed = parse_scan_output(raw, "brew vulns --quiet --json").expect("salvaged");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].formula, "openssl@3");
+    }
+
+    #[test]
+    fn parse_scan_output_pure_prose_yields_empty_not_error() {
+        // No JSON structure at all on a clean exit → treat as "no results"
+        // rather than a json_parse error in the user's face (issue #62).
+        assert_eq!(
+            parse_scan_output("whatcable: skipped (unsupported source)\n", "test")
+                .expect("no error")
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn parse_scan_output_malformed_payload_still_errors() {
+        // A bracketed-but-broken payload is a genuine problem, still surfaced.
+        let err = parse_scan_output("notice\n[ {broken json ]\n", "brew vulns --quiet --json")
+            .unwrap_err();
+        assert!(matches!(err, BrewError::JsonParse { .. }));
+    }
+
+    #[test]
+    fn extract_json_document_skips_surrounding_lines() {
+        let raw = "lead\n  [1,2,3]  \ntrail";
+        assert_eq!(extract_json_document(raw).as_deref(), Some("  [1,2,3]  "));
+        assert_eq!(extract_json_document("no json here").as_deref(), None);
+    }
+
     // ----- validate_formula_name -----
 
     #[test]
@@ -579,6 +699,35 @@ mod tests {
             "lib_foo",
         ] {
             assert!(validate_formula_name(name).is_ok(), "should accept: {name}");
+        }
+    }
+
+    #[test]
+    fn validate_formula_name_accepts_tap_qualified_names() {
+        // Issue #92: third-party tap formulae are `user/repo/name`.
+        for name in [
+            "anomalyco/tap/opencode",
+            "homebrew/core/wget",
+            "user-name/repo_2/formula@1.2",
+        ] {
+            assert!(validate_formula_name(name).is_ok(), "should accept: {name}");
+        }
+    }
+
+    #[test]
+    fn validate_formula_name_rejects_malformed_slashes() {
+        // `/` is allowed only in the exact `user/repo/name` shape.
+        for bad in [
+            "/leading",
+            "trailing/",
+            "a//b",
+            "two/segments",
+            "a/b/c/d",
+            "a/../b",
+            "../etc/passwd",
+            "./relative",
+        ] {
+            assert!(validate_formula_name(bad).is_err(), "should reject: {bad}");
         }
     }
 

--- a/src-tauri/src/vulns/client.rs
+++ b/src-tauri/src/vulns/client.rs
@@ -33,7 +33,7 @@ use std::process::Stdio;
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio::process::Command;
 
-use crate::brew::exec::run_brew_capture;
+use crate::brew::exec::{apply_brew_env, run_brew_capture};
 use crate::error::{truncate_tail, BrewError};
 
 /// Tolerant subprocess wrapper for `brew vulns`. Differs from
@@ -57,6 +57,7 @@ async fn run_vulns_capture(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    apply_brew_env(&mut cmd);
 
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
@@ -279,6 +280,7 @@ pub async fn check_brew_vulns_installed(brew: &Path) -> Result<bool, BrewError> 
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    apply_brew_env(&mut cmd);
 
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
@@ -494,6 +496,7 @@ async fn brew_version(brew: &Path) -> Result<String, BrewError> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    apply_brew_env(&mut cmd);
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
         _ => BrewError::Io {


### PR DESCRIPTION
Two related fixes, one commit each.

## fix(vulns): tap-qualified names (#92) + JSON salvage (#62) — `08950d1`
The two remaining `bug` keepers in the backlog, both vulnerability-scan failures.

- **#92 `invalid_argument`** — scan rejected tap-qualified formula names like `anomalyco/tap/opencode`. `validate_formula_name`/`validateFormulaName` now allow `/` but enforce the exact `user/repo/name` shape (reject empty segments, leading/trailing slash, `.`/`..`, deeper paths). `scan_one`/`scanOne` match the reported record by exact name **or** last `/`-segment, since `brew vulns` may echo the bare or tap-qualified form.
- **#62 `json_parse`** — scan choked when brew printed a banner/notice on stdout around the `--json` document. `parse_scan_output`/`parseScanOutput` salvage the JSON document out of line-oriented noise (first `[`/`{` line → last `]`/`}` line); a malformed bracketed payload still errors, and pure prose on a clean exit yields `[]` instead of a scary parse error. Tauri also gains `--quiet` (native already had it).

## fix(privacy): disable Homebrew's own analytics on app-spawned brew — `6821364`
A user reported a startup connection to `*.influxdata.com`. Root cause is **Homebrew's own analytics** (brew 4.0+ pings InfluxDB Cloud unless `HOMEBREW_NO_ANALYTICS=1`), fired because we shell out to `brew` — not Brew Browser telemetry (we send none). We now set `HOMEBREW_NO_ANALYTICS=1` on every brew subprocess we spawn; the user's own global brew-analytics preference for manual CLI use is untouched.

- Tauri: `brew/exec.rs` gains `BREW_ENV` + `apply_brew_env()`, applied at the 2 exec spawn sites + 3 `vulns/client.rs` spawn sites.
- Native: `BrewService.brewEnvironment()` (`NO_ANALYTICS` + `NO_COLOR` + `NO_ENV_HINTS`) at `runCapture` + `runStreaming`.

See https://docs.brew.sh/Analytics.

## Tests
- cargo: 77 vulns tests + analytics env test, 0 failures (+8 new)
- swift: 145 tests in 22 suites passed (+9 new)
- Both shells in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)