### PR TITLE
fix(vulns): correct Exposure over-count + native GHSA parity; window & cleanup fixes

### DIFF
--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -940,6 +940,15 @@ public final class AppModel {
     /// frame it as stale ("re-scan to confirm"), never a confident all-clear.
     var vulnScannedThisSession = false
 
+    /// Whether the displayed scan is a fresh run this session (`.live`) or the
+    /// persisted result restored from a previous launch (`.cache`). nil before
+    /// any scan has ever run. Mirrors the Tauri `vulnerabilities.source`
+    /// (`vulnerabilities.svelte.ts:152-155`); drives the Exposure card's
+    /// "· source:" label so a stale cached scan is visibly distinct from a
+    /// fresh one (the gap that made native vs Tauri counts look discrepant).
+    enum VulnSource: String, Sendable { case live, cache }
+    var vulnSource: VulnSource?
+
     /// Aggregate severity rollup across every package in `vulnIndex`. Mirrors
     /// the Tauri `vulnerabilities.severityCounts` derived value: per-severity
     /// finding counts + the count of packages with ≥1 finding.
@@ -1321,9 +1330,14 @@ public final class AppModel {
         var args = ["cleanup", "--prune=all"]
         if scrub { args.append("--scrub") }
         if verbose { args.append("--verbose") }
-        let ok = await startJob("Cleaning up Homebrew cache", args: args, startedAt: Date().timeIntervalSince1970)
+        _ = await startJob("Cleaning up Homebrew cache", args: args, startedAt: Date().timeIntervalSince1970)
         cleanupRunning = false
-        if ok { await loadStorage() }
+        // Re-measure storage + refresh the "frees ~X" estimate regardless of exit
+        // status: `brew cleanup` can free space yet exit non-zero (a file it
+        // couldn't remove), and even a partial cleanup changes what's
+        // reclaimable. loadStorage re-fetches cleanupReclaimableBytes
+        // independently, so a stale estimate can't survive. (Mirrors Tauri.)
+        await loadStorage()
     }
 
     /// Toolbar Refresh — reload whichever surface is showing.
@@ -1717,14 +1731,23 @@ public final class AppModel {
         // smaller set) and was ~331× slower. Run off the main actor so the
         // blocking subprocess I/O doesn't freeze the UI.
         let service = vulns
-        guard let findings = try? await Task.detached(priority: .utility, operation: {
+        guard let rawFindings = try? await Task.detached(priority: .utility, operation: {
             try await service.scanAll()
         }).value else { return }
+        // Best-effort GHSA enrichment — same posture + position as Tauri's
+        // scan_all (commands/vulns.rs:218): fills richer advisory text for
+        // GHSA findings from api.github.com, gated on the GitHub master toggle.
+        // Does NOT change severity or counts. Token read once (anonymous if
+        // signed out); skipped entirely when GitHub is off/Offline Mode on.
+        let token = settings.githubAllowed ? GitHubService.storedToken() : nil
+        let findings = await VulnsEnrich.enrich(
+            rawFindings, githubEnabled: settings.githubAllowed, token: token)
         // Replace wholesale so an uninstalled package drops out of the caches.
         vulnFindings = findings
         vulnIndex = findings.mapValues { VulnSummary.from($0) }
         vulnLastScannedAt = Date()
         vulnScannedThisSession = true
+        vulnSource = .live
         // Persist so the result survives relaunch — the Exposure card shows the
         // last scan instantly instead of re-scanning at every launch.
         persistVulns()
@@ -1756,6 +1779,8 @@ public final class AppModel {
            let findings = try? JSONDecoder().decode([String: [VulnFinding]].self, from: data) {
             vulnFindings = findings
             vulnIndex = findings.mapValues { VulnSummary.from($0) }
+            // Restored from disk → a previous session's scan, not a fresh run.
+            vulnSource = .cache
         }
         let ts = UserDefaults.standard.double(forKey: Self.vulnScannedAtKey)
         if ts > 0 { vulnLastScannedAt = Date(timeIntervalSince1970: ts) }

--- a/native/Sources/BrewBrowserKit/DashboardView.swift
+++ b/native/Sources/BrewBrowserKit/DashboardView.swift
@@ -719,19 +719,25 @@ struct ExposureCard: View {
                     }
                 } else {
                     // Findings — per-severity counts + "X of N" summary line.
+                    // Severity tones mirror the Tauri chips exactly
+                    // (Dashboard.svelte `exp-sev--*`): critical+high danger (red),
+                    // medium warning (amber/orange), low info (blue), unknown
+                    // neutral (gray).
                     HStack(spacing: 16) {
                         sevCount(exposure.critical, "critical", .red)
                         sevCount(exposure.high, "high", .red)
                         sevCount(exposure.medium, "medium", .orange)
-                        sevCount(exposure.low, "low", .yellow)
+                        sevCount(exposure.low, "low", .blue)
                         if exposure.unknown > 0 { sevCount(exposure.unknown, "unknown", .gray) }
                         Spacer()
                     }
-                    // The severity chips count individual advisories (findings);
-                    // a package can have several — so spell out "N findings across
-                    // M of T packages" instead of letting the chips look like they
-                    // should sum to the package count.
-                    Text("\(exposure.total) finding\(exposure.total == 1 ? "" : "s") across \(exposure.vulnerablePackages) of \(model.totalPackages) installed packages")
+                    // Summary line — identical to the Tauri Exposure card
+                    // (Dashboard.svelte): "<N> findings across <M> of <T> installed
+                    // packages · source: <live|cache>". The chips count individual
+                    // advisories (findings), so the line spells out the findings
+                    // total separately from the package count; the source label
+                    // makes a stale (cache) scan visibly distinct from a fresh one.
+                    Text("**\(exposure.total)** finding\(exposure.total == 1 ? "" : "s") across **\(exposure.vulnerablePackages)** of **\(model.totalPackages)** installed packages\(model.vulnSource.map { " · source: \($0.rawValue)" } ?? "")")
                         .font(.callout).foregroundStyle(.secondary)
                     Button("View vulnerable packages →") {
                         model.openVulnerableInLibrary()

--- a/native/Sources/BrewBrowserKit/GitHubService.swift
+++ b/native/Sources/BrewBrowserKit/GitHubService.swift
@@ -932,6 +932,14 @@ public struct GitHubService: Sendable {
         return (token, username, scopes)
     }
 
+    /// Best-effort read of the stored GitHub access token for authenticated
+    /// API calls outside the sign-in flow (e.g. GHSA enrichment). nil when
+    /// signed out. ONE Keychain access. Mirrors the Tauri
+    /// `github::auth::read_token` used by `vulns::enrich`.
+    static func storedToken() -> String? {
+        readCredential()?.token
+    }
+
     /// Persist the combined credential item (token + username + scopes) as one
     /// JSON blob — one Keychain item so every later read is a single prompt.
     private static func writeCredential(token: String, username: String?, scopes: [String]) {

--- a/native/Sources/BrewBrowserKit/VulnsEnrich.swift
+++ b/native/Sources/BrewBrowserKit/VulnsEnrich.swift
@@ -1,0 +1,317 @@
+import Foundation
+
+/// GHSA enrichment layer — the native Swift port of
+/// `src-tauri/src/vulns/enrich.rs` (parity charter: same endpoint, same cache
+/// shape, same merge semantics).
+///
+/// `brew vulns` gives the canonical CVE/GHSA id + a severity, but the
+/// title/details/patched-version fields are often a one-line OSV stub when the
+/// real advisory lives on GitHub. For any `GHSA-…` finding this fetches
+/// `GET https://api.github.com/advisories/{id}` and merges the richer fields
+/// back in. Like the Rust version it **never changes the finding's severity**
+/// (severity stays whatever `brew vulns` reported) and never adds or removes
+/// findings — so it has no effect on the Exposure card counts; it enriches the
+/// PackageDetail advisory text.
+///
+/// Gated on the same independent GitHub master toggle as the Tauri layer
+/// (`AppSettings.githubAllowed`). Best-effort throughout: a 404/429/parse
+/// failure leaves the finding untouched and moves on. Results are cached to
+/// `<App Support>/brew-browser/ghsa_cache.json` (the same file Tauri writes),
+/// 7-day TTL, 500-entry LRU, fail-soft on a corrupt/foreign entry.
+enum VulnsEnrich {
+    static let apiBase = "https://api.github.com"
+    static let cacheTTL: TimeInterval = 7 * 24 * 60 * 60
+    static let cacheMaxEntries = 500
+    static let schemaVersion = 1
+    static let maxResponseBytes = 256 * 1024
+    static let httpTimeout: TimeInterval = 10
+
+    // MARK: - Public entry point
+
+    /// Enrich every GHSA finding across the install-wide scan result. No-op
+    /// (returns the input unchanged) when GitHub is disabled or there are no
+    /// GHSA ids to enrich. `token` is read once by the caller (a Keychain miss
+    /// just means anonymous rate limit). The cache dedups fetches across
+    /// packages that share an advisory.
+    static func enrich(
+        _ findingsByPackage: [String: [VulnFinding]],
+        githubEnabled: Bool,
+        token: String?,
+        session: URLSession = .shared,
+        apiBase: String = VulnsEnrich.apiBase,
+        cacheDir: URL? = VulnsEnrich.defaultCacheDir()
+    ) async -> [String: [VulnFinding]] {
+        guard githubEnabled else { return findingsByPackage }
+        // Early-exit before touching the cache file when nothing is enrichable.
+        let hasGhsa = findingsByPackage.values.contains { findings in
+            findings.contains { isValidGhsaId($0.rawId) }
+        }
+        guard hasGhsa else { return findingsByPackage }
+
+        var cache = GhsaCache.load(dir: cacheDir)
+        var out: [String: [VulnFinding]] = [:]
+        out.reserveCapacity(findingsByPackage.count)
+
+        for (name, findings) in findingsByPackage {
+            var merged: [VulnFinding] = []
+            merged.reserveCapacity(findings.count)
+            for finding in findings {
+                guard isValidGhsaId(finding.rawId) else { merged.append(finding); continue }
+                if let adv = cache.getFresh(finding.rawId) {
+                    merged.append(mergeInto(finding, adv))
+                    continue
+                }
+                if let adv = await fetchAdvisory(finding.rawId, token: token,
+                                                 session: session, apiBase: apiBase) {
+                    cache.put(finding.rawId, adv)
+                    merged.append(mergeInto(finding, adv))
+                } else {
+                    merged.append(finding) // 404 / rate-limit / parse-fail → unchanged
+                }
+            }
+            out[name] = merged
+        }
+
+        cache.saveIfDirty(dir: cacheDir)
+        return out
+    }
+
+    // MARK: - Merge (mirrors enrich.rs `merge_into`)
+
+    /// Fold richer advisory fields into a finding. Only non-empty fields
+    /// overwrite (a sparse advisory must not clobber a populated OSV record);
+    /// `fixedIn` is only set when the finding had none; references are deduped.
+    /// **Severity is never changed.**
+    static func mergeInto(_ finding: VulnFinding, _ adv: GhsaAdvisory) -> VulnFinding {
+        var refs = finding.references
+        for r in adv.references where !r.isEmpty && !refs.contains(r) { refs.append(r) }
+        return VulnFinding(
+            id: finding.id,
+            rawId: finding.rawId,
+            severity: finding.severity, // unchanged — parity with merge_into
+            summary: adv.summary.isEmpty ? finding.summary : adv.summary,
+            details: adv.description.isEmpty ? finding.details : adv.description,
+            fixedIn: finding.fixedIn ?? (adv.firstPatchedVersion?.isEmpty == false ? adv.firstPatchedVersion : nil),
+            references: refs,
+            published: finding.published
+        )
+    }
+
+    // MARK: - GHSA id validation (mirrors `is_valid_ghsa_id`)
+
+    /// `GHSA-xxxx-xxxx-xxxx` where each group is exactly 4 ASCII alphanumerics.
+    /// Defense in depth: keeps malformed ids out of the URL + cache keys.
+    static func isValidGhsaId(_ id: String) -> Bool {
+        guard id.hasPrefix("GHSA-") else { return false }
+        let parts = id.dropFirst("GHSA-".count).split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3 else { return false }
+        return parts.allSatisfy { p in
+            p.count == 4 && p.allSatisfy { c in
+                ("a"..."z").contains(c) || ("A"..."Z").contains(c) || ("0"..."9").contains(c)
+            }
+        }
+    }
+
+    // MARK: - HTTP (mirrors `fetch_advisory_with`)
+
+    /// Fetch one advisory. Returns nil on 404/429/403/parse-fail (skip and
+    /// continue) or any network error — every failure is best-effort.
+    static func fetchAdvisory(
+        _ ghsaId: String,
+        token: String?,
+        session: URLSession,
+        apiBase: String
+    ) async -> GhsaAdvisory? {
+        guard let url = URL(string: "\(apiBase)/advisories/\(ghsaId)") else { return nil }
+        var req = URLRequest(url: url, timeoutInterval: httpTimeout)
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        if let token, !token.isEmpty {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        guard let (data, resp) = try? await session.data(for: req),
+              let http = resp as? HTTPURLResponse else { return nil }
+
+        switch http.statusCode {
+        case 200: break
+        case 404, 429, 403: return nil // withdrawn / rate limited → skip
+        default: return nil
+        }
+        guard data.count <= maxResponseBytes else { return nil }
+        return parseAdvisory(data)
+    }
+
+    /// Decode the api.github.com advisory body into our merge shape. Tolerant
+    /// of missing/extra fields (forward-compat). nil on un-parseable JSON.
+    static func parseAdvisory(_ data: Data) -> GhsaAdvisory? {
+        guard let raw = try? JSONDecoder().decode(RawAdvisory.self, from: data) else { return nil }
+        let refs = raw.references.map(\.url).filter { !$0.isEmpty }
+        let firstPatched = raw.vulnerabilities
+            .compactMap { $0.firstPatchedVersion }
+            .first { !$0.isEmpty }
+        return GhsaAdvisory(
+            summary: raw.summary,
+            description: raw.description,
+            severity: raw.severity,
+            references: refs,
+            firstPatchedVersion: firstPatched
+        )
+    }
+
+    static let userAgent = "brew-browser (+https://github.com/msitarzewski/brew-browser)"
+
+    /// `<App Support>/brew-browser/ghsa_cache.json` — the same path the Tauri
+    /// app uses (`dirs::data_dir()/brew-browser`), so the two share the cache.
+    static func defaultCacheDir() -> URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("brew-browser", isDirectory: true)
+    }
+}
+
+// MARK: - Wire shapes (api.github.com advisory response)
+
+/// Tolerant decode of the advisory response — every field optional-with-default
+/// so a future api.github.com schema change can't break the scan.
+struct RawAdvisory: Decodable {
+    var summary = ""
+    var description = ""
+    var severity = ""
+    var references: [RawReference] = []
+    var vulnerabilities: [RawVulnerableProduct] = []
+
+    enum CodingKeys: String, CodingKey { case summary, description, severity, references, vulnerabilities }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        summary = (try? c.decode(String.self, forKey: .summary)) ?? ""
+        description = (try? c.decode(String.self, forKey: .description)) ?? ""
+        severity = (try? c.decode(String.self, forKey: .severity)) ?? ""
+        references = (try? c.decode([RawReference].self, forKey: .references)) ?? []
+        vulnerabilities = (try? c.decode([RawVulnerableProduct].self, forKey: .vulnerabilities)) ?? []
+    }
+    // Test/seam initializer.
+    init(summary: String = "", description: String = "", severity: String = "",
+         references: [RawReference] = [], vulnerabilities: [RawVulnerableProduct] = []) {
+        self.summary = summary; self.description = description; self.severity = severity
+        self.references = references; self.vulnerabilities = vulnerabilities
+    }
+}
+
+struct RawReference: Decodable { var url: String = "" }
+struct RawVulnerableProduct: Decodable {
+    var firstPatchedVersion: String?
+    enum CodingKeys: String, CodingKey { case firstPatchedVersion = "first_patched_version" }
+}
+
+// MARK: - Merge shape + cache (mirrors enrich.rs GhsaAdvisory / GhsaCache)
+
+/// The advisory fields we actually merge. camelCase keys match the Tauri
+/// on-disk shape so the shared `ghsa_cache.json` round-trips between apps.
+struct GhsaAdvisory: Codable, Equatable, Sendable {
+    var summary: String = ""
+    var description: String = ""
+    var severity: String = ""
+    var references: [String] = []
+    var firstPatchedVersion: String?
+}
+
+struct GhsaCacheEntry: Codable, Sendable {
+    var fetchedAt: Date
+    var advisory: GhsaAdvisory
+
+    enum CodingKeys: String, CodingKey { case fetchedAt, advisory }
+    init(fetchedAt: Date, advisory: GhsaAdvisory) {
+        self.fetchedAt = fetchedAt; self.advisory = advisory
+    }
+    // fetchedAt is an RFC3339 string on disk (chrono `DateTime<Utc>` shape).
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let raw = try c.decode(String.self, forKey: .fetchedAt)
+        guard let date = GhsaCache.parseDate(raw) else {
+            throw DecodingError.dataCorruptedError(forKey: .fetchedAt, in: c,
+                debugDescription: "unparseable fetchedAt: \(raw)")
+        }
+        fetchedAt = date
+        advisory = try c.decode(GhsaAdvisory.self, forKey: .advisory)
+    }
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(GhsaCache.formatDate(fetchedAt), forKey: .fetchedAt)
+        try c.encode(advisory, forKey: .advisory)
+    }
+}
+
+struct GhsaCacheFile: Codable, Sendable {
+    var schemaVersion: Int = VulnsEnrich.schemaVersion
+    var entries: [String: GhsaCacheEntry] = [:]
+    var fetchCount: Int = 0
+}
+
+/// In-memory cache wrapper with a dirty flag so writes batch after a scan.
+struct GhsaCache {
+    var file: GhsaCacheFile
+    var dirty: Bool
+
+    static func newEmpty() -> GhsaCache {
+        GhsaCache(file: GhsaCacheFile(schemaVersion: VulnsEnrich.schemaVersion), dirty: false)
+    }
+
+    static func path(dir: URL) -> URL { dir.appendingPathComponent("ghsa_cache.json") }
+
+    /// Fail-soft load: missing/oversize/corrupt/future-schema → empty.
+    static func load(dir: URL?) -> GhsaCache {
+        guard let dir else { return newEmpty() }
+        let url = path(dir: dir)
+        guard let data = try? Data(contentsOf: url),
+              data.count <= 2 * 1024 * 1024,
+              let file = try? JSONDecoder().decode(GhsaCacheFile.self, from: data) else {
+            return newEmpty()
+        }
+        if file.schemaVersion > VulnsEnrich.schemaVersion { return newEmpty() }
+        return GhsaCache(file: file, dirty: false)
+    }
+
+    func saveIfDirty(dir: URL?) {
+        guard dirty, let dir else { return }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(file), data.count <= 2 * 1024 * 1024 else { return }
+        try? data.write(to: Self.path(dir: dir), options: .atomic)
+    }
+
+    /// Fresh (within TTL) advisory for `ghsaId`, else nil.
+    func getFresh(_ ghsaId: String) -> GhsaAdvisory? {
+        guard let entry = file.entries[ghsaId] else { return nil }
+        guard Date().timeIntervalSince(entry.fetchedAt) < VulnsEnrich.cacheTTL else { return nil }
+        return entry.advisory
+    }
+
+    /// Insert/replace, evicting the oldest entry by `fetchedAt` at the cap.
+    mutating func put(_ ghsaId: String, _ advisory: GhsaAdvisory) {
+        if file.entries[ghsaId] == nil, file.entries.count >= VulnsEnrich.cacheMaxEntries {
+            if let oldest = file.entries.min(by: { $0.value.fetchedAt < $1.value.fetchedAt })?.key {
+                file.entries.removeValue(forKey: oldest)
+            }
+        }
+        file.entries[ghsaId] = GhsaCacheEntry(fetchedAt: Date(), advisory: advisory)
+        file.fetchCount += 1
+        dirty = true
+    }
+
+    // RFC3339 helpers — match chrono's `DateTime<Utc>` JSON so the cache file
+    // is shared with the Tauri app. Encode with fractional seconds; decode
+    // tolerant of presence/absence of them. Formatters are built per-call:
+    // ISO8601DateFormatter isn't Sendable, so it can't be a shared static
+    // under Swift 6 strict concurrency, and the cost is negligible here.
+    private static func makeFormatter(fractional: Bool) -> ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = fractional ? [.withInternetDateTime, .withFractionalSeconds] : [.withInternetDateTime]
+        return f
+    }
+    static func formatDate(_ date: Date) -> String {
+        makeFormatter(fractional: true).string(from: date)
+    }
+    static func parseDate(_ raw: String) -> Date? {
+        makeFormatter(fractional: true).date(from: raw) ?? makeFormatter(fractional: false).date(from: raw)
+    }
+}

--- a/native/Tests/BrewBrowserKitTests/VulnsEnrichTests.swift
+++ b/native/Tests/BrewBrowserKitTests/VulnsEnrichTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+@testable import BrewBrowserKit
+
+/// Parity tests for the Swift GHSA enrichment layer, mirroring the Rust
+/// `src-tauri/src/vulns/enrich.rs` test suite (id validation, merge semantics,
+/// advisory parsing, cache round-trip + fail-soft + LRU, and the gating
+/// no-ops). The live HTTP fetch is exercised via `parseAdvisory` on captured
+/// bodies rather than a mocked URLSession.
+@Suite("VulnsEnrich")
+struct VulnsEnrichTests {
+
+    private func finding(_ rawId: String,
+                         severity: VulnSeverity = .high,
+                         summary: String = "stub",
+                         details: String = "stub details",
+                         fixedIn: String? = nil,
+                         references: [String] = []) -> VulnFinding {
+        VulnFinding(id: rawId, rawId: rawId, severity: severity, summary: summary,
+                    details: details, fixedIn: fixedIn, references: references, published: nil)
+    }
+
+    private func tempDir() -> URL {
+        let d = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghsa-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    // ---------- GHSA id validation ----------
+
+    @Test func ghsaIdAcceptsCanonicalForm() {
+        #expect(VulnsEnrich.isValidGhsaId("GHSA-abcd-1234-wxyz"))
+        #expect(VulnsEnrich.isValidGhsaId("GHSA-0000-0000-0000"))
+        #expect(VulnsEnrich.isValidGhsaId("GHSA-AAAA-bbbb-CCCC"))
+    }
+
+    @Test func ghsaIdRejectsMalformed() {
+        for bad in ["", "GHSA-", "GHSA-abc-1234-wxyz", "GHSA-abcd-1234",
+                    "ghsa-abcd-1234-wxyz", "GHSA-abcd-1234-wxyz-extra",
+                    "GHSA-ab/d-1234-wxyz", "GHSA-ab.d-1234-wxyz",
+                    "CVE-2024-1", "GHSA-abcd-1234-wxy", "../etc/passwd"] {
+            #expect(!VulnsEnrich.isValidGhsaId(bad), "must reject: \(bad)")
+        }
+    }
+
+    // ---------- merge semantics (mirrors merge_into) ----------
+
+    @Test func mergeOnlyOverwritesNonEmptyAndNeverSeverity() {
+        let v = finding("GHSA-abcd-1234-wxyz", severity: .high,
+                        summary: "OSV summary", details: "OSV details",
+                        fixedIn: "2.0.0", references: ["https://osv.example/x"])
+        let sparse = GhsaAdvisory() // all empty
+        let out = VulnsEnrich.mergeInto(v, sparse)
+        #expect(out.summary == "OSV summary")
+        #expect(out.details == "OSV details")
+        #expect(out.fixedIn == "2.0.0")
+        #expect(out.references == ["https://osv.example/x"])
+        #expect(out.severity == .high) // severity NEVER changes
+    }
+
+    @Test func mergeDedupesReferences() {
+        let v = finding("GHSA-abcd-1234-wxyz", references: ["https://example.com/a"])
+        let adv = GhsaAdvisory(references: ["https://example.com/a", "https://example.com/b"])
+        let out = VulnsEnrich.mergeInto(v, adv)
+        #expect(out.references == ["https://example.com/a", "https://example.com/b"])
+    }
+
+    @Test func mergePreservesExistingFixedIn() {
+        let v = finding("GHSA-abcd-1234-wxyz", fixedIn: "2.0.0")
+        let adv = GhsaAdvisory(firstPatchedVersion: "3.0.0")
+        #expect(VulnsEnrich.mergeInto(v, adv).fixedIn == "2.0.0")
+    }
+
+    @Test func mergeFillsFixedInWhenMissing() {
+        let v = finding("GHSA-abcd-1234-wxyz", fixedIn: nil)
+        let adv = GhsaAdvisory(firstPatchedVersion: "3.0.0")
+        #expect(VulnsEnrich.mergeInto(v, adv).fixedIn == "3.0.0")
+    }
+
+    // ---------- advisory parsing ----------
+
+    @Test func parseAdvisoryDefaults() {
+        let adv = VulnsEnrich.parseAdvisory(Data("{}".utf8))
+        #expect(adv?.summary == "")
+        #expect(adv?.references.isEmpty == true)
+        #expect(adv?.firstPatchedVersion == nil)
+    }
+
+    @Test func parseAdvisoryIgnoresUnknownFieldsAndMaps() {
+        let json = """
+        {"summary":"boom","description":"details","severity":"high",
+         "references":[{"url":"https://example.com/x"}],
+         "vulnerabilities":[{"first_patched_version":"1.0.0"}],
+         "new_field_2027":{"nested":true}}
+        """
+        let adv = VulnsEnrich.parseAdvisory(Data(json.utf8))
+        #expect(adv?.summary == "boom")
+        #expect(adv?.description == "details")
+        #expect(adv?.references == ["https://example.com/x"])
+        #expect(adv?.firstPatchedVersion == "1.0.0")
+    }
+
+    @Test func parseAdvisoryPicksFirstNonEmptyPatchedVersion() {
+        let json = """
+        {"vulnerabilities":[{"first_patched_version":null},
+         {"first_patched_version":""},{"first_patched_version":"2.0.0"},
+         {"first_patched_version":"3.0.0"}]}
+        """
+        #expect(VulnsEnrich.parseAdvisory(Data(json.utf8))?.firstPatchedVersion == "2.0.0")
+    }
+
+    // ---------- cache ----------
+
+    @Test func cacheRoundTrips() {
+        let dir = tempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        var c = GhsaCache.newEmpty()
+        let adv = GhsaAdvisory(summary: "Buffer overflow", description: "details",
+                               severity: "high", references: ["https://example.com/adv"],
+                               firstPatchedVersion: "3.2.1")
+        c.put("GHSA-abcd-1234-wxyz", adv)
+        c.saveIfDirty(dir: dir)
+        #expect(FileManager.default.fileExists(atPath: GhsaCache.path(dir: dir).path))
+
+        let loaded = GhsaCache.load(dir: dir)
+        #expect(loaded.getFresh("GHSA-abcd-1234-wxyz") == adv)
+        #expect(loaded.file.fetchCount == 1)
+    }
+
+    @Test func cacheLoadHandlesCorruptFile() {
+        let dir = tempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        try? Data("{not json".utf8).write(to: GhsaCache.path(dir: dir))
+        let c = GhsaCache.load(dir: dir)
+        #expect(c.file.entries.isEmpty)
+        #expect(c.file.schemaVersion == VulnsEnrich.schemaVersion)
+    }
+
+    @Test func cacheLoadHandlesFutureSchema() {
+        let dir = tempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let future = GhsaCacheFile(schemaVersion: VulnsEnrich.schemaVersion + 1, entries: [:], fetchCount: 99)
+        try? JSONEncoder().encode(future).write(to: GhsaCache.path(dir: dir))
+        let c = GhsaCache.load(dir: dir)
+        #expect(c.file.entries.isEmpty)
+        #expect(c.file.fetchCount == 0)
+    }
+
+    @Test func cacheEvictsOldestAtCap() {
+        var c = GhsaCache.newEmpty()
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        for i in 0..<VulnsEnrich.cacheMaxEntries {
+            let id = String(format: "GHSA-pkg%04d-0000-0000", i)
+            c.file.entries[id] = GhsaCacheEntry(fetchedAt: base.addingTimeInterval(Double(i)),
+                                                advisory: GhsaAdvisory())
+        }
+        #expect(c.file.entries.count == VulnsEnrich.cacheMaxEntries)
+        c.put("GHSA-newr-comr-1234", GhsaAdvisory())
+        #expect(c.file.entries.count == VulnsEnrich.cacheMaxEntries)
+        #expect(c.file.entries["GHSA-pkg0000-0000-0000"] == nil) // oldest evicted
+        #expect(c.file.entries["GHSA-newr-comr-1234"] != nil)
+    }
+
+    @Test func cacheGetFreshRejectsStale() {
+        var c = GhsaCache.newEmpty()
+        c.file.entries["GHSA-abcd-1234-wxyz"] = GhsaCacheEntry(
+            fetchedAt: Date().addingTimeInterval(-(VulnsEnrich.cacheTTL + 60)),
+            advisory: GhsaAdvisory(summary: "old"))
+        #expect(c.getFresh("GHSA-abcd-1234-wxyz") == nil) // past TTL
+    }
+
+    // ---------- enrich gating (no-op paths, no network) ----------
+
+    @Test func enrichNoOpWhenGithubDisabled() async {
+        let dir = tempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let input = ["wget": [finding("GHSA-abcd-1234-wxyz")]]
+        let out = await VulnsEnrich.enrich(input, githubEnabled: false, token: nil, cacheDir: dir)
+        #expect(out == input)
+        #expect(!FileManager.default.fileExists(atPath: GhsaCache.path(dir: dir).path))
+    }
+
+    @Test func enrichNoOpWhenNoGhsaIds() async {
+        let dir = tempDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let input = ["wget": [finding("CVE-2024-1"), finding("CVE-2024-99999")]]
+        let out = await VulnsEnrich.enrich(input, githubEnabled: true, token: nil, cacheDir: dir)
+        #expect(out == input) // CVE-only → untouched, early-exit before cache
+        #expect(!FileManager.default.fileExists(atPath: GhsaCache.path(dir: dir).path))
+    }
+}

--- a/src-tauri/src/commands/vulns.rs
+++ b/src-tauri/src/commands/vulns.rs
@@ -224,18 +224,26 @@ pub async fn vulns_scan_all(
     }
 
     // Write results + fingerprint back to the cache, then persist.
+    //
+    // REPLACE the per-package entries with exactly this scan's results — a full
+    // `brew vulns` run is authoritative for the whole install. The old code
+    // merged via `put` and returned the entire accumulated cache, so stale
+    // records (old versions, packages OSV no longer flags) piled up and the
+    // Exposure rollup over-reported vs the raw `brew vulns` output (e.g. 33
+    // findings shown vs 17 actual). This mirrors the native shell's wholesale
+    // replace and keeps the two shells' Exposure cards in agreement.
     {
         let mut cache = state.vulns_cache.lock().await;
-        for r in results {
-            cache.put(
+        cache.replace_full_scan(results.into_iter().map(|r| {
+            (
                 VulnKey {
                     kind: PackageKind::Formula,
                     name: r.formula,
                     version: r.version,
                 },
                 r.vulnerabilities,
-            );
-        }
+            )
+        }));
         cache.record_fingerprint(fingerprint.clone());
         cache.save_if_dirty(&state.app_data_dir).await?;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,10 +76,11 @@ pub fn run() {
         // would otherwise try the manifest endpoint.
         .plugin(tauri_plugin_updater::Builder::new().build())
         // Issue #17 — persist the window's size + position across launches.
-        // The plugin auto-saves geometry when the window is moved/resized and
-        // on exit, then restores it on the next launch. Default StateFlags
-        // cover size + position (plus maximized/fullscreen) — exactly what the
-        // issue asks for. No frontend wiring: registration is the feature.
+        // The plugin restores saved geometry on launch and saves on a clean
+        // exit. We ALSO save eagerly on every resize/move (see
+        // `.on_window_event` below) so geometry survives dev hot-reloads,
+        // force-quits, and crashes — not just a graceful Cmd-Q. Default
+        // StateFlags cover size + position (plus maximized/fullscreen).
         .plugin(tauri_plugin_window_state::Builder::default().build());
 
     // The native menu is macOS-idiomatic: on macOS it populates the
@@ -126,6 +127,37 @@ pub fn run() {
                 }
             }
             Ok(())
+        })
+        // Persist window geometry shortly after a resize/move settles, not only
+        // on a clean exit — so size/position survive dev hot-reloads,
+        // force-quits, and crashes (issue #17), WITHOUT writing on every drag
+        // tick. macOS fires Resized/Moved continuously during a drag, so we
+        // debounce: each event bumps a generation counter and schedules a save
+        // 400ms out; only the last event in the burst still matches the counter
+        // and actually writes the ~200-byte state file.
+        .on_window_event(|window, event| {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            use tauri::Manager;
+            use tauri_plugin_window_state::{AppHandleExt, StateFlags};
+
+            static RESIZE_GEN: AtomicU64 = AtomicU64::new(0);
+            const DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(400);
+
+            if matches!(
+                event,
+                tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_)
+            ) {
+                let my_gen = RESIZE_GEN.fetch_add(1, Ordering::SeqCst) + 1;
+                let app = window.app_handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(DEBOUNCE).await;
+                    // Skip if a newer resize/move arrived during the wait —
+                    // only the final geometry of the burst is written.
+                    if RESIZE_GEN.load(Ordering::SeqCst) == my_gen {
+                        let _ = app.save_window_state(StateFlags::all());
+                    }
+                });
+            }
         })
         .invoke_handler(tauri::generate_handler![
             app_version,

--- a/src-tauri/src/vulns/cache.rs
+++ b/src-tauri/src/vulns/cache.rs
@@ -275,6 +275,33 @@ impl VulnsCache {
         self.dirty = true;
     }
 
+    /// Replace ALL per-package entries with the given full-scan results.
+    ///
+    /// A full `brew vulns` run is authoritative for the entire install: the
+    /// packages it returns ARE the complete set of currently-vulnerable
+    /// packages. Merging each result via [`Self::put`] (the old behavior) and
+    /// returning the whole cache left stale records — old versions of a package
+    /// and packages OSV no longer flags — accumulating across scans, which
+    /// inflated the Exposure rollup far above the raw `brew vulns` count (a real
+    /// bug: 33 findings surfaced vs 17 actually reported). Clearing first drops
+    /// that cruft so the cache always mirrors the latest scan, exactly like the
+    /// native shell's wholesale `vulnFindings = findings`. Fingerprint state is
+    /// preserved (set separately via [`Self::record_fingerprint`]).
+    pub fn replace_full_scan(&mut self, records: impl IntoIterator<Item = (VulnKey, Vec<RawVuln>)>) {
+        self.file.entries.clear();
+        let now = Utc::now();
+        for (key, vulns) in records {
+            self.file.entries.insert(
+                key.to_storage_key(),
+                ScanRecord {
+                    scanned_at: now,
+                    vulns,
+                },
+            );
+        }
+        self.dirty = true;
+    }
+
     /// Drop an entry by key. Marks dirty if anything was removed.
     /// Called after a successful upgrade/uninstall so the next scan
     /// can't surface a CVE for a version the user no longer has.
@@ -392,6 +419,27 @@ mod tests {
         c.put(key("ripgrep", "14.1.0"), vec![]);
         let got = c.get_fresh(&key("ripgrep", "14.1.0")).expect("present");
         assert!(got.vulns.is_empty());
+    }
+
+    #[test]
+    fn replace_full_scan_drops_stale_entries() {
+        // Regression for the Exposure over-count: a full scan must REPLACE the
+        // cache, not accumulate. Prior scans left stale records.
+        let mut c = VulnsCache::new_empty();
+        c.put(key("augeas", "1.14.0"), vec![vuln("CVE-OLD")]); // old version
+        c.put(key("ghostscript", "10.0"), vec![vuln("CVE-GONE-1"), vuln("CVE-GONE-2")]); // no longer flagged
+        assert_eq!(c.file.entries.len(), 2);
+
+        // Fresh full scan: only augeas@1.14.1 with two findings.
+        c.replace_full_scan([(key("augeas", "1.14.1"), vec![vuln("CVE-A"), vuln("CVE-B")])]);
+
+        assert_eq!(c.file.entries.len(), 1, "stale entries must be cleared");
+        assert!(c.get_any(&key("augeas", "1.14.1")).is_some());
+        assert!(c.get_any(&key("augeas", "1.14.0")).is_none(), "old version dropped");
+        assert!(c.get_any(&key("ghostscript", "10.0")).is_none(), "no-longer-flagged dropped");
+        let total: usize = c.file.entries.values().map(|r| r.vulns.len()).sum();
+        assert_eq!(total, 2, "finding total reflects the scan, not the accumulation");
+        assert!(c.dirty);
     }
 
     #[test]

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -57,14 +57,16 @@
     if (diskLoading) return;
     diskLoading = true;
     diskError = null;
+    if (force) {
+      try { await diskUsageClearCache(); } catch { /* best-effort */ }
+    }
+    // Refresh the reclaimable estimate INDEPENDENTLY of the (slower, fallible)
+    // disk re-measure: a disk-probe error must not leave a stale "frees ~X"
+    // hint after a cleanup. `cleanupPreview` re-runs `brew cleanup -n`, which
+    // reports ~nothing once the cache has actually been cleared.
+    brewCleanupPreview().then((p) => { cleanupPreview = p; }).catch(() => { cleanupPreview = null; });
     try {
-      if (force) {
-        try { await diskUsageClearCache(); } catch { /* best-effort */ }
-      }
       disk = await diskUsage();
-      // Best-effort reclaimable estimate for the cleanup hint; never blocks the
-      // disk report, and a failure just hides the hint.
-      brewCleanupPreview().then((p) => { cleanupPreview = p; }).catch(() => { cleanupPreview = null; });
     } catch (e) {
       diskError = `Disk probe failed: ${isBrewError(e) ? brewErrorMessage(e) : String(e)}`;
     } finally {
@@ -112,15 +114,16 @@
     cleanupConfirmOpen = false;
     cleanupRunning = true;
     try {
-      const ok = await streamJob(
+      await streamJob(
         "Cleaning up Homebrew cache",
         `brew cleanup --prune=all${cleanupScrub ? " --scrub" : ""}${cleanupVerbose ? " --verbose" : ""}`,
         (onEvent) => brewCleanup(cleanupScrub, cleanupVerbose, onEvent),
       );
-      if (ok) {
-        // Cache shrank — re-measure the Storage card + refresh the estimate.
-        await loadDisk(true);
-      }
+      // Re-measure the Storage card + refresh the "frees ~X" estimate after the
+      // cleanup completes — NOT gated on a clean exit. `brew cleanup` can free
+      // space and still exit non-zero (a file it couldn't remove), and even a
+      // partial cleanup changes what's reclaimable, so always reconcile.
+      await loadDisk(true);
     } catch (e) {
       reportableToastError("Cleanup failed", e);
     } finally {
@@ -1134,10 +1137,16 @@
                   </span>
                 {/if}
               </div>
+              <!-- Findings total + package count: the severity chips count
+                   individual advisories, so spell out "N findings across M of T
+                   packages" rather than implying the chips sum to the package
+                   count. Kept identical to the native Exposure card. -->
               <p class="exp-summary">
+                <strong>{fmt(exposureCounts.total)}</strong>
+                {exposureCounts.total === 1 ? "finding" : "findings"} across
                 <strong>{fmt(exposureCounts.vulnerablePackages)}</strong>
                 of <strong>{fmt(counts.total)}</strong>
-                installed packages have known vulnerabilities
+                installed packages
                 {#if exposureSource}
                   · source: <span class="exp-source">{exposureSource}</span>
                 {/if}


### PR DESCRIPTION
A batch of vulnerability/Exposure and Storage-card fixes, plus a window-state fix.

## Exposure over-count (the headline bug)
The Tauri Exposure card reported **33 findings / 13 packages** while the raw `brew vulns --quiet --json` (and the native shell) reported **17 / 12**. Root cause: `commands/vulns.rs::scan_all` wrote each result into the persistent vulns cache via `put()` and then returned the **entire accumulated cache** — keyed by `(kind, name, version)` and never pruned — so stale records (old versions, packages OSV no longer flags) piled up across scans.

**Fix:** `VulnsCache::replace_full_scan` — a full `brew vulns` run is authoritative for the whole install, so it now **clears + replaces** the cache (mirrors the native shell's wholesale replace). Both shells now match the raw command. (+1 regression test reproducing the stale-entry accumulation.)

## Native GHSA enrichment parity
New `VulnsEnrich.swift` — a faithful Swift port of `src-tauri/src/vulns/enrich.rs`: `GET api.github.com/advisories/{id}`, shared `ghsa_cache.json` (7-day TTL, LRU, fail-soft), merge `summary`/`details`/`fixed-in`/`references` (never severity), gated on the GitHub master toggle, wired into `scanAllVulns`. This also makes the native Settings line *"…enriched from api.github.com"* actually true. (+16 unit tests mirroring the Rust suite.)

## Exposure card parity
Native now tracks scan **source** (`live`/`cache`) and shows the label; both shells unified to *"N findings across M of T installed packages · source: X"*.

## Window geometry (#17)
Saves on a **debounced** resize/move (400ms) in addition to clean exit, so size/position survive dev hot-reloads, force-quits, and crashes — not just a graceful Cmd-Q. (A stale 2700×1892 had been restored with no way to tell it was stale.)

## Cleanup estimate refresh
The Storage card's "frees ~X GB" hint now refreshes after a cleanup **regardless of exit status**, decoupled from the (fallible) disk re-measure so a probe error can't leave a stale number.

## Tests
cargo **658** · swift **161** (+16) · vitest **35** · svelte-check **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)