### PR TITLE
feat: in-app control of brew command options (#47, #98 reactive, #13, #102, #100)

### DIFF
--- a/native/Sources/BrewBrowser/BrewBrowserApp.swift
+++ b/native/Sources/BrewBrowser/BrewBrowserApp.swift
@@ -45,7 +45,7 @@ struct BrewBrowserApp: App {
         // Native Settings scene — opened by ⌘, the app menu, or the toolbar
         // gear (SettingsLink in ContentView). ⌘, is provided by SwiftUI.
         Settings {
-            SettingsView(updater: updater)
+            SettingsView(model: model, updater: updater)
         }
     }
 }

--- a/native/Sources/BrewBrowserKit/ActivityView.swift
+++ b/native/Sources/BrewBrowserKit/ActivityView.swift
@@ -160,7 +160,32 @@ struct ActivityDrawer: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(AppModel.failureNoticeTitle(for: job.label))
                         .font(.callout.weight(.semibold))
-                    if let friendly = job.friendlyFailureMessage {
+                    if let recovery = BrewRecovery.classify(job) {
+                        // A recoverable brew failure (#13/#102/#100): offer a
+                        // one-click retry with the right flag instead of Terminal.
+                        Text(recovery.reason)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        HStack(spacing: 8) {
+                            ForEach(recovery.choices) { spec in
+                                Button(spec.label) {
+                                    Task { await model.runRecovery(recovery, choice: spec.choice) }
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .tint(spec.isDanger ? .red : .accentColor)
+                                .help(spec.hint)
+                            }
+                        }
+                        .padding(.top, 2)
+                        if let hint = recovery.choices.first?.hint {
+                            Text(hint)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    } else if let friendly = job.friendlyFailureMessage {
                         // Known brew failure with a curated friendly message.
                         Text(friendly)
                             .font(.caption)

--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -1809,20 +1809,22 @@ public final class AppModel {
 
     // MARK: - Detail actions
 
-    func upgradeDetail() async {
+    func upgradeDetail(greedy: Bool = false) async {
         guard let pkg = detailPackage else { return }
         var args = ["upgrade"]
         if pkg.kind == .cask { args.append("--cask") }
         args.append(pkg.name)
+        if greedy { args.append("--greedy") }
         let ok = await startJob("Upgrading \(pkg.name)", args: args, startedAt: Date().timeIntervalSince1970)
         if ok, let pkg = detailPackage { await loadDetail(pkg) }
     }
 
-    func uninstallDetail() async {
+    /// Uninstall the detail package. `ignoreDependencies` adds
+    /// `--ignore-dependencies` to force removal when another installed package
+    /// still requires it ("Force remove", #100).
+    func uninstallDetail(ignoreDependencies: Bool = false) async {
         guard let pkg = detailPackage else { return }
-        var args = ["uninstall"]
-        if pkg.kind == .cask { args.append("--cask") }
-        args.append(pkg.name)
+        let args = BrewArgs.uninstall(pkg.name, kind: pkg.kind, ignoreDependencies: ignoreDependencies)
         let ok = await startJob("Uninstalling \(pkg.name)", args: args, startedAt: Date().timeIntervalSince1970)
         if ok { closeDetail() }
     }
@@ -1831,11 +1833,12 @@ public final class AppModel {
     /// detail afterward so the footer flips Install → Uninstall + the meta table
     /// shows the now-installed version. Output streams into the Activity drawer;
     /// on failure the job shows `failed` with brew's actual error lines.
-    func installDetail() async {
+    /// Install the detail package. `adopt` adds `--adopt` (cask-only) to take
+    /// over a matching app already on disk instead of erroring "already an
+    /// App" (#13/#102); `force` overwrites it.
+    func installDetail(force: Bool = false, adopt: Bool = false) async {
         guard let pkg = detailPackage else { return }
-        var args = ["install"]
-        if pkg.kind == .cask { args.append("--cask") }
-        args.append(pkg.name)
+        let args = BrewArgs.install(pkg.name, kind: pkg.kind, force: force, adopt: adopt)
         let ok = await startJob("Installing \(pkg.name)", args: args, startedAt: Date().timeIntervalSince1970)
         if ok, let pkg = detailPackage { await loadDetail(pkg) }
     }
@@ -1845,9 +1848,11 @@ public final class AppModel {
     /// `brew upgrade` — upgrade every outdated formula and cask, as a streaming
     /// Activity job. Mirrors Tauri's Dashboard "Upgrade all". `startJob` calls
     /// `refresh()` on completion, so the outdated count updates itself.
-    func upgradeAll() async {
+    func upgradeAll(greedy: Bool = false) async {
         guard outdatedCount > 0 else { return }
-        await startJob("Upgrading all packages", args: ["upgrade"], startedAt: Date().timeIntervalSince1970)
+        var args = ["upgrade"]
+        if greedy { args.append("--greedy") }
+        await startJob("Upgrading all packages", args: args, startedAt: Date().timeIntervalSince1970)
     }
 
     /// Curated upgrade — run ONE `brew upgrade <name1> <name2> …` for the
@@ -1855,10 +1860,39 @@ public final class AppModel {
     /// Mirrors the Tauri `brew_upgrade_many` flow (`UpgradeModal.svelte`): a
     /// single streaming Activity job rather than N sequential ones. `startJob`
     /// calls `refresh()` on completion, so the outdated count self-updates.
-    func upgradeMany(_ names: [String]) async {
+    func upgradeMany(_ names: [String], greedy: Bool = false) async {
         guard !names.isEmpty else { return }
         let label = names.count == 1 ? "Upgrading \(names[0])" : "Upgrading \(names.count) packages"
-        await startJob(label, args: ["upgrade"] + names, startedAt: Date().timeIntervalSince1970)
+        var args = ["upgrade"] + names
+        if greedy { args.append("--greedy") }
+        await startJob(label, args: args, startedAt: Date().timeIntervalSince1970)
+    }
+
+    /// `brew autoremove` — remove formulae installed only as now-unneeded
+    /// dependencies (#47). Confirm-gated in the UI; streams into Activity.
+    /// Mirrors Tauri `brew_autoremove`; `startJob` refreshes on completion.
+    func autoremove() async {
+        await startJob("Removing unused dependencies", args: ["autoremove"], startedAt: Date().timeIntervalSince1970)
+    }
+
+    /// Re-run a failed command with the flag a recovery choice implies
+    /// (#13/#102/#100). Streams a fresh Activity job, exactly like the first
+    /// attempt. Mirrors the Tauri `runRecovery` in `util/recovery.ts`.
+    func runRecovery(_ option: BrewRecovery.Option, choice: BrewRecovery.Choice) async {
+        let args: [String]
+        let label: String
+        switch choice {
+        case .adopt:
+            args = BrewArgs.install(option.name, kind: option.kind, adopt: true)
+            label = "Adopting \(option.name)"
+        case .overwrite:
+            args = BrewArgs.install(option.name, kind: option.kind, force: true)
+            label = "Reinstalling \(option.name)"
+        case .forceRemove:
+            args = BrewArgs.uninstall(option.name, kind: option.kind, ignoreDependencies: true)
+            label = "Force-removing \(option.name)"
+        }
+        await startJob(label, args: args, startedAt: Date().timeIntervalSince1970)
     }
 
     // MARK: - Snapshots (Brewfile)

--- a/native/Sources/BrewBrowserKit/BrewRecovery.swift
+++ b/native/Sources/BrewBrowserKit/BrewRecovery.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// In-app recovery for the two brew failures users hit most and previously
+/// could only fix from Terminal (issues #13/#102, #100). The native mirror of
+/// the Tauri `src/lib/util/recovery.ts` (parity charter: same classification,
+/// same choices, same flags).
+///
+/// `classify` is a PURE function of a failed `ActivityJob`: it parses the brew
+/// command + stderr to decide whether a one-click retry with a different flag
+/// would succeed, and which choices to offer. `ActivityView` renders the
+/// resulting buttons on the failure card; `AppModel.runRecovery` re-runs the
+/// command with the chosen flag.
+enum BrewRecovery {
+    enum Action: Sendable { case install, uninstall }
+    enum Choice: String, Sendable { case adopt, overwrite, forceRemove }
+
+    /// One retry button.
+    struct ChoiceSpec: Identifiable, Sendable {
+        let choice: Choice
+        let label: String
+        /// Danger styling (overwrite/force) vs the safe, recommended adopt.
+        let isDanger: Bool
+        let hint: String
+        var id: String { choice.rawValue }
+    }
+
+    struct Option: Sendable {
+        let action: Action
+        let name: String
+        let kind: InstalledPackage.Kind
+        /// Plain-language headline of what went wrong.
+        let reason: String
+        /// Retry choices, in display order (safest first).
+        let choices: [ChoiceSpec]
+    }
+
+    /// Parse `[brew] <action> [--cask|--formula] <name> [flags…]` from a job's
+    /// display command. nil when it isn't a recognizable install/uninstall.
+    static func parse(command: String) -> (Action, String, InstalledPackage.Kind)? {
+        var toks = command.split(whereSeparator: { $0 == " " }).map(String.init)
+        if toks.first == "brew" { toks.removeFirst() }
+        guard let verb = toks.first else { return nil }
+        let action: Action
+        switch verb {
+        case "install": action = .install
+        case "uninstall": action = .uninstall
+        default: return nil
+        }
+        let kind: InstalledPackage.Kind = toks.contains("--cask") ? .cask : .formula
+        guard let name = toks.dropFirst().first(where: { !$0.hasPrefix("-") }) else { return nil }
+        return (action, name, kind)
+    }
+
+    /// Decide whether a failed job can be retried in-app, and how. Pure.
+    /// Returns nil for success, cancel, no-exit-code (our spawn failure), or an
+    /// unrecognized error.
+    static func classify(_ job: ActivityJob) -> Option? {
+        guard job.status == .failed, job.exitCode != nil else { return nil }
+        guard let (action, name, kind) = parse(command: job.command) else { return nil }
+        let text = job.lines.map(\.text).joined(separator: "\n").lowercased()
+
+        if action == .install, alreadyExists(text) {
+            var choices: [ChoiceSpec] = []
+            // --adopt only exists for casks; it's the safe, recommended fix.
+            if kind == .cask {
+                choices.append(ChoiceSpec(
+                    choice: .adopt, label: "Adopt existing", isDanger: false,
+                    hint: "Let Homebrew manage the copy already on your Mac (keeps it in place)."))
+            }
+            choices.append(ChoiceSpec(
+                choice: .overwrite, label: "Overwrite", isDanger: true,
+                hint: "Replace the existing copy with a fresh Homebrew install."))
+            return Option(action: action, name: name, kind: kind,
+                          reason: "\(name) is already installed outside Homebrew.",
+                          choices: choices)
+        }
+
+        if action == .uninstall, requiredBy(text) {
+            return Option(action: action, name: name, kind: kind,
+                          reason: "\(name) is still required by another installed package.",
+                          choices: [ChoiceSpec(
+                            choice: .forceRemove, label: "Force remove", isDanger: true,
+                            hint: "Remove it anyway, ignoring packages that depend on it.")])
+        }
+
+        return nil
+    }
+
+    // brew's "already installed outside Homebrew" message (cask "App" + the
+    // rarer formula/binary variants), across brew versions.
+    private static func alreadyExists(_ lowered: String) -> Bool {
+        lowered.contains("already an app at")
+            || lowered.contains("it seems there is already a")
+    }
+
+    // brew's dependency-protection refusal on uninstall.
+    private static func requiredBy(_ lowered: String) -> Bool {
+        lowered.contains("refusing to uninstall") || lowered.contains("required by")
+    }
+}

--- a/native/Sources/BrewBrowserKit/BrewService.swift
+++ b/native/Sources/BrewBrowserKit/BrewService.swift
@@ -112,6 +112,40 @@ private actor ProcessRegistry {
     func cancel(_ id: UUID) { live[id]?.terminate() }
 }
 
+/// Pure builders for the brew argv of each write action, the native mirror of
+/// the Tauri `commands::actions` arg-builders (parity charter: same flag logic,
+/// same data contract). Free of I/O so they're unit-testable without spawning
+/// brew. The `--cask`/no-`--formula` convention matches the existing native
+/// commands (brew defaults to a formula); the new flags are the additions.
+enum BrewArgs {
+    /// `brew install [--cask] <name> [--adopt] [--force]`. `--adopt` is cask-only
+    /// and takes over a matching app already on disk instead of erroring with
+    /// "It seems there is already an App at…" (#13/#102). `--force` overwrites.
+    static func install(_ name: String, kind: InstalledPackage.Kind,
+                        force: Bool = false, adopt: Bool = false) -> [String] {
+        var args = ["install"]
+        if kind == .cask { args.append("--cask") }
+        args.append(name)
+        if adopt && kind == .cask { args.append("--adopt") }
+        if force { args.append("--force") }
+        return args
+    }
+
+    /// `brew uninstall [--cask] <name> [--zap] [--ignore-dependencies]`.
+    /// `--ignore-dependencies` forces removal even when another installed
+    /// package still requires it — the in-app escape for "Refusing to
+    /// uninstall … because it is required by…" (#100).
+    static func uninstall(_ name: String, kind: InstalledPackage.Kind,
+                          zap: Bool = false, ignoreDependencies: Bool = false) -> [String] {
+        var args = ["uninstall"]
+        if kind == .cask { args.append("--cask") }
+        args.append(name)
+        if zap && kind == .cask { args.append("--zap") }
+        if ignoreDependencies { args.append("--ignore-dependencies") }
+        return args
+    }
+}
+
 struct BrewService: Sendable {
     private let registry = ProcessRegistry()
 

--- a/native/Sources/BrewBrowserKit/DashboardView.swift
+++ b/native/Sources/BrewBrowserKit/DashboardView.swift
@@ -210,7 +210,7 @@ struct UpdatesCard: View {
                     Button("Choose…") { showUpgradeSheet = true }
                         .controlSize(.small)
                     Button {
-                        Task { await model.upgradeAll() }
+                        Task { await model.upgradeAll(greedy: LocalPrefs.shared.greedyUpgrade) }
                     } label: {
                         Label("Upgrade all (\(model.outdatedCount))", systemImage: "arrow.up.circle")
                     }

--- a/native/Sources/BrewBrowserKit/LocalPrefs.swift
+++ b/native/Sources/BrewBrowserKit/LocalPrefs.swift
@@ -73,6 +73,7 @@ final class LocalPrefs {
         static let theme = "brew-browser.theme"
         static let defaultSection = "brew-browser.default-section"
         static let confirmDestructive = "brew-browser.confirm-destructive"
+        static let greedyUpgrade = "brew-browser.greedy-upgrade"
         static let activityMaxJobs = "brew-browser.activity.max-jobs"
         static let activityMaxLines = "brew-browser.activity.max-lines"
         static let sidebarCollapsed = "brew-browser.sidebar-collapsed"
@@ -89,6 +90,9 @@ final class LocalPrefs {
     private static let defaultTheme: AppTheme = .system
     private static let defaultLandingSection: LandingSection = .dashboard
     private static let defaultConfirmDestructive = true
+    /// Greedy upgrades (include self-updating casks) — off by default, mirrors
+    /// the Tauri `ui.greedyUpgrade` (ui.svelte.ts). Issues #47/#31.
+    private static let defaultGreedyUpgrade = false
     private static let defaultSidebarCollapsed = false
     /// Native-only: post a macOS notification when a brew task finishes while
     /// the app isn't frontmost. Opt-in (off) so we never prompt unprompted.
@@ -116,6 +120,12 @@ final class LocalPrefs {
     /// Whether destructive actions require a confirm dialog (ui.svelte.ts:117).
     var confirmDestructive: Bool {
         didSet { defaults.set(confirmDestructive, forKey: Key.confirmDestructive) }
+    }
+
+    /// Whether `brew upgrade` runs with `--greedy` so self-updating casks are
+    /// included (#47/#31). Off by default. Mirrors Tauri `ui.greedyUpgrade`.
+    var greedyUpgrade: Bool {
+        didSet { defaults.set(greedyUpgrade, forKey: Key.greedyUpgrade) }
     }
 
     /// Max retained Activity jobs; clamped to 1...1000 (ui.svelte.ts:244-248).
@@ -215,6 +225,13 @@ final class LocalPrefs {
             self.confirmDestructive = defaults.bool(forKey: Key.confirmDestructive)
         } else {
             self.confirmDestructive = Self.defaultConfirmDestructive
+        }
+
+        // greedyUpgrade — absent key defaults to false.
+        if defaults.object(forKey: Key.greedyUpgrade) != nil {
+            self.greedyUpgrade = defaults.bool(forKey: Key.greedyUpgrade)
+        } else {
+            self.greedyUpgrade = Self.defaultGreedyUpgrade
         }
 
         // activityMaxJobs — clamp on read.

--- a/native/Sources/BrewBrowserKit/PackageDetailView.swift
+++ b/native/Sources/BrewBrowserKit/PackageDetailView.swift
@@ -756,7 +756,7 @@ struct PackageDetailView: View {
                 if isInstalled {
                     if info?.isOutdated == true {
                         Button {
-                            Task { await model.upgradeDetail() }
+                            Task { await model.upgradeDetail(greedy: LocalPrefs.shared.greedyUpgrade) }
                         } label: { Label("Upgrade", systemImage: "arrow.up.circle") }
                         .buttonStyle(.borderedProminent)
                         .disabled(model.actionRunning)

--- a/native/Sources/BrewBrowserKit/SettingsView.swift
+++ b/native/Sources/BrewBrowserKit/SettingsView.swift
@@ -24,7 +24,14 @@ public struct SettingsView: View {
     /// tab's "Check now" / auto-check controls drive the shared instance (Bundle C).
     private let updater: UpdaterController
 
-    public init(updater: UpdaterController) { self.updater = updater }
+    /// The shared app model, passed in so the Brew tab's Autoremove action can
+    /// stream a job into Activity (parity with the Tauri Settings → Brew).
+    private let model: AppModel
+
+    public init(model: AppModel, updater: UpdaterController) {
+        self.model = model
+        self.updater = updater
+    }
 
     public var body: some View {
         TabView(selection: $selected) {
@@ -34,7 +41,7 @@ public struct SettingsView: View {
                 .tabItem { Label("Network", systemImage: "globe") }.tag(SettingsTab.network.rawValue)
             GitHubSettings()
                 .tabItem { Label("GitHub", systemImage: "chevron.left.forwardslash.chevron.right") }.tag(SettingsTab.github.rawValue)
-            BrewSettings()
+            BrewSettings(model: model)
                 .tabItem { Label("Brew", systemImage: "mug") }.tag(SettingsTab.brew.rawValue)
             UpdatesSettings(updater: updater)
                 .tabItem { Label("Updates", systemImage: "arrow.down.circle") }.tag(SettingsTab.updates.rawValue)
@@ -243,10 +250,12 @@ private struct GitHubSettings: View {
 // MARK: - Brew
 
 private struct BrewSettings: View {
+    @Bindable var model: AppModel
     @State private var prefs = LocalPrefs.shared
     @State private var brew = BrewService()
     @State private var analytics: Bool?
     @State private var analyticsBusy = false
+    @State private var confirmAutoremove = false
 
     var body: some View {
         Form {
@@ -272,10 +281,29 @@ private struct BrewSettings: View {
                 Text("Destructive actions (Uninstall, Zap, Delete Brewfile) ask before proceeding.")
                     .font(.caption).foregroundStyle(.secondary)
             }
+
+            SwiftUI.Section("Advanced") {
+                Toggle("Greedy upgrades (include self-updating casks)", isOn: $prefs.greedyUpgrade)
+                Text("Adds `--greedy` to `brew upgrade` so casks that update themselves (like Chrome) are upgraded too. Off by default — greedy can churn apps that manage their own updates.")
+                    .font(.caption).foregroundStyle(.secondary)
+
+                Button("Autoremove unused dependencies") {
+                    if prefs.confirmDestructive { confirmAutoremove = true }
+                    else { Task { await model.autoremove() } }
+                }
+                Text("Runs `brew autoremove` to uninstall formulae that were installed only as dependencies and are no longer needed by anything.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
         .padding(20)
         .task { analytics = await brew.getAnalytics() }
+        .confirmationDialog("Remove unused dependencies?", isPresented: $confirmAutoremove, titleVisibility: .visible) {
+            Button("Autoremove", role: .destructive) { Task { await model.autoremove() } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This runs `brew autoremove`, which uninstalls formulae that were installed only as dependencies and are no longer required by anything else.")
+        }
     }
 }
 

--- a/native/Sources/BrewBrowserKit/UpgradeSheet.swift
+++ b/native/Sources/BrewBrowserKit/UpgradeSheet.swift
@@ -70,7 +70,7 @@ struct UpgradeSheet: View {
                 Button {
                     let names = rows.filter { isChecked($0) }.map(\.name)
                     onClose()
-                    Task { await model.upgradeMany(names) }
+                    Task { await model.upgradeMany(names, greedy: LocalPrefs.shared.greedyUpgrade) }
                 } label: {
                     Label(
                         selectedCount == 0

--- a/native/Tests/BrewBrowserKitTests/BrewOutputParsingTests.swift
+++ b/native/Tests/BrewBrowserKitTests/BrewOutputParsingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import BrewBrowserKit
 
@@ -279,5 +280,90 @@ struct BrewEnvironmentTests {
         let env = BrewService.brewEnvironment()
         #expect(env["HOMEBREW_NO_COLOR"] == "1")
         #expect(env["HOMEBREW_NO_ENV_HINTS"] == "1")
+    }
+}
+
+@Suite("BrewArgs")
+struct BrewArgsTests {
+    // Parity with the Rust `commands::actions::tests` arg-builders.
+
+    @Test func installAdoptIsCaskOnly() {
+        #expect(BrewArgs.install("cursor", kind: .cask, adopt: true)
+            == ["install", "--cask", "cursor", "--adopt"])
+        // Formulae have no on-disk app to adopt → flag dropped.
+        #expect(BrewArgs.install("wget", kind: .formula, adopt: true)
+            == ["install", "wget"])
+    }
+
+    @Test func installAdoptAndForceOrder() {
+        #expect(BrewArgs.install("cursor", kind: .cask, force: true, adopt: true)
+            == ["install", "--cask", "cursor", "--adopt", "--force"])
+    }
+
+    @Test func installPlainUnchanged() {
+        #expect(BrewArgs.install("cursor", kind: .cask) == ["install", "--cask", "cursor"])
+    }
+
+    @Test func uninstallIgnoreDependenciesForceRemove() {
+        #expect(BrewArgs.uninstall("gstreamer-runtime", kind: .cask, ignoreDependencies: true)
+            == ["uninstall", "--cask", "gstreamer-runtime", "--ignore-dependencies"])
+    }
+
+    @Test func uninstallZapIsCaskOnly() {
+        // --zap dropped for a formula; --ignore-dependencies still applies.
+        #expect(BrewArgs.uninstall("foo", kind: .formula, zap: true, ignoreDependencies: true)
+            == ["uninstall", "foo", "--ignore-dependencies"])
+    }
+}
+
+@Suite("BrewRecovery")
+struct BrewRecoveryTests {
+    // Parity with the Tauri `util/recovery.test.ts`.
+
+    private func failed(_ command: String, _ stderr: [String],
+                        status: ActivityJob.JobStatus = .failed,
+                        exitCode: Int32? = 1) -> ActivityJob {
+        ActivityJob(
+            id: UUID(), label: "x", command: command, startedAt: 0,
+            status: status,
+            lines: stderr.map { ActivityLine(stream: .stderr, text: $0) },
+            exitCode: exitCode)
+    }
+
+    @Test func caskAlreadyExistsOffersAdoptAndOverwrite() {
+        let r = BrewRecovery.classify(failed("brew install --cask google-chrome",
+            ["Error: It seems there is already an App at '/Applications/Google Chrome.app'."]))
+        #expect(r != nil)
+        #expect(r?.action == .install)
+        #expect(r?.kind == .cask)
+        #expect(r?.name == "google-chrome")
+        #expect(r?.choices.map(\.choice) == [.adopt, .overwrite])
+    }
+
+    @Test func formulaAlreadyExistsOffersOnlyOverwrite() {
+        let r = BrewRecovery.classify(failed("brew install --formula foo",
+            ["Error: It seems there is already a Binary at '/opt/homebrew/bin/foo'."]))
+        #expect(r?.kind == .formula)
+        #expect(r?.choices.map(\.choice) == [.overwrite])
+    }
+
+    @Test func uninstallRequiredByOffersForceRemove() {
+        let r = BrewRecovery.classify(failed("brew uninstall --cask gstreamer-runtime",
+            ["Error: Refusing to uninstall gstreamer-runtime",
+             "because it is required by wine-stable, which is currently installed."]))
+        #expect(r?.action == .uninstall)
+        #expect(r?.name == "gstreamer-runtime")
+        #expect(r?.choices.map(\.choice) == [.forceRemove])
+    }
+
+    @Test func nonRecoverableCasesReturnNil() {
+        // Succeeded.
+        #expect(BrewRecovery.classify(failed("brew install --cask x", ["whatever"], status: .succeeded)) == nil)
+        // No exit code = our spawn failure.
+        #expect(BrewRecovery.classify(failed("brew install --cask x", ["boom"], exitCode: nil)) == nil)
+        // Unrelated upgrade failure.
+        #expect(BrewRecovery.classify(failed("brew upgrade", ["Error: other"])) == nil)
+        // Install failure that isn't an existing-app conflict.
+        #expect(BrewRecovery.classify(failed("brew install --cask x", ["Error: Download failed: 404"])) == nil)
     }
 }

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -16,31 +16,81 @@ use crate::error::BrewError;
 use crate::state::AppState;
 use crate::types::{BrewStreamEvent, JobResult, PackageKind};
 
+// ---------- Pure argv builders ----------
+//
+// The flag logic for each write command lives in these pure functions so it
+// is unit-testable without spawning brew or wiring a Channel/AppState. The
+// commands below call them, then derive the user-facing display string with
+// `display_for`.
+
+fn kind_flag(kind: PackageKind) -> &'static str {
+    match kind {
+        PackageKind::Formula => "--formula",
+        PackageKind::Cask => "--cask",
+    }
+}
+
+/// `brew install <kind> <name> [--adopt] [--force]`. `--adopt` is cask-only:
+/// it takes over a matching app already present on disk instead of erroring
+/// with "It seems there is already an App at…" — the in-app fix for #13/#102.
+/// `--force` overwrites instead of adopting (the heavier hammer).
+fn install_args(name: &str, kind: PackageKind, force: bool, adopt: bool) -> Vec<String> {
+    let mut args = vec!["install".to_string(), kind_flag(kind).to_string(), name.to_string()];
+    if adopt && matches!(kind, PackageKind::Cask) {
+        args.push("--adopt".to_string());
+    }
+    if force {
+        args.push("--force".to_string());
+    }
+    args
+}
+
+/// `brew uninstall <kind> <name> [--zap] [--ignore-dependencies]`. `--zap` is
+/// cask-only (removes leftover files). `--ignore-dependencies` forces removal
+/// even when another installed package still requires it — the in-app escape
+/// for "Refusing to uninstall … because it is required by…" (#100).
+fn uninstall_args(name: &str, kind: PackageKind, zap: bool, ignore_dependencies: bool) -> Vec<String> {
+    let mut args = vec!["uninstall".to_string(), kind_flag(kind).to_string(), name.to_string()];
+    if zap && matches!(kind, PackageKind::Cask) {
+        args.push("--zap".to_string());
+    }
+    if ignore_dependencies {
+        args.push("--ignore-dependencies".to_string());
+    }
+    args
+}
+
+/// `brew upgrade [names...] [--greedy]`. Empty `names` upgrades everything.
+/// `--greedy` also upgrades casks that self-update (`auto_updates` / `version
+/// :latest`), which brew otherwise skips — the option requested in #47/#31.
+fn upgrade_args(names: &[String], greedy: bool) -> Vec<String> {
+    let mut args = vec!["upgrade".to_string()];
+    args.extend(names.iter().cloned());
+    if greedy {
+        args.push("--greedy".to_string());
+    }
+    args
+}
+
+/// User-facing command string for the Activity log, derived from the argv.
+fn display_for(args: &[String]) -> String {
+    format!("brew {}", args.join(" "))
+}
+
 #[tauri::command]
 pub async fn brew_install(
     name: String,
     kind: PackageKind,
     force: bool,
+    adopt: bool,
     on_event: Channel<BrewStreamEvent>,
     state: State<'_, AppState>,
 ) -> Result<JobResult, BrewError> {
     validate_package_name(&name)?;
     let path = state.require_brew_path().await?;
 
-    let kind_flag = match kind {
-        PackageKind::Formula => "--formula",
-        PackageKind::Cask => "--cask",
-    };
-    let mut args = vec!["install".to_string(), kind_flag.to_string(), name.clone()];
-    if force {
-        args.push("--force".to_string());
-    }
-    let display = format!(
-        "brew install {} {}{}",
-        kind_flag,
-        name,
-        if force { " --force" } else { "" }
-    );
+    let args = install_args(&name, kind, force, adopt);
+    let display = display_for(&args);
     let jobs = state.jobs.clone();
     let lock = state.brew_write_lock.clone();
 
@@ -58,26 +108,15 @@ pub async fn brew_uninstall(
     name: String,
     kind: PackageKind,
     zap: bool,
+    ignore_dependencies: bool,
     on_event: Channel<BrewStreamEvent>,
     state: State<'_, AppState>,
 ) -> Result<JobResult, BrewError> {
     validate_package_name(&name)?;
     let path = state.require_brew_path().await?;
 
-    let kind_flag = match kind {
-        PackageKind::Formula => "--formula",
-        PackageKind::Cask => "--cask",
-    };
-    let mut args = vec!["uninstall".to_string(), kind_flag.to_string(), name.clone()];
-    if zap && matches!(kind, PackageKind::Cask) {
-        args.push("--zap".to_string());
-    }
-    let display = format!(
-        "brew uninstall {} {}{}",
-        kind_flag,
-        name,
-        if zap { " --zap" } else { "" }
-    );
+    let args = uninstall_args(&name, kind, zap, ignore_dependencies);
+    let display = display_for(&args);
     let jobs = state.jobs.clone();
     let lock = state.brew_write_lock.clone();
 
@@ -93,6 +132,7 @@ pub async fn brew_uninstall(
 #[tauri::command]
 pub async fn brew_upgrade(
     name: Option<String>,
+    greedy: bool,
     on_event: Channel<BrewStreamEvent>,
     state: State<'_, AppState>,
 ) -> Result<JobResult, BrewError> {
@@ -101,14 +141,9 @@ pub async fn brew_upgrade(
     }
     let path = state.require_brew_path().await?;
 
-    let mut args = vec!["upgrade".to_string()];
-    if let Some(n) = name.as_ref() {
-        args.push(n.clone());
-    }
-    let display = match name.as_ref() {
-        Some(n) => format!("brew upgrade {}", n),
-        None => "brew upgrade".to_string(),
-    };
+    let names: Vec<String> = name.into_iter().collect();
+    let args = upgrade_args(&names, greedy);
+    let display = display_for(&args);
     let jobs = state.jobs.clone();
     let lock = state.brew_write_lock.clone();
 
@@ -132,6 +167,7 @@ pub async fn brew_upgrade(
 #[tauri::command]
 pub async fn brew_upgrade_many(
     names: Vec<String>,
+    greedy: bool,
     on_event: Channel<BrewStreamEvent>,
     state: State<'_, AppState>,
 ) -> Result<JobResult, BrewError> {
@@ -147,9 +183,8 @@ pub async fn brew_upgrade_many(
     }
     let path = state.require_brew_path().await?;
 
-    let mut args = vec!["upgrade".to_string()];
-    args.extend(names.iter().cloned());
-    let display = format!("brew upgrade {}", names.join(" "));
+    let args = upgrade_args(&names, greedy);
+    let display = display_for(&args);
     let jobs = state.jobs.clone();
     let lock = state.brew_write_lock.clone();
 
@@ -250,6 +285,31 @@ pub async fn brew_cleanup(
     result
 }
 
+/// `brew autoremove` — remove formulae that were installed only as
+/// dependencies and are no longer needed by anything (issue #47). Streams like
+/// the other write commands and is confirm-gated in the UI. Changes the install
+/// set, so caches are invalidated on success.
+#[tauri::command]
+pub async fn brew_autoremove(
+    on_event: Channel<BrewStreamEvent>,
+    state: State<'_, AppState>,
+) -> Result<JobResult, BrewError> {
+    let path = state.require_brew_path().await?;
+
+    let args = vec!["autoremove".to_string()];
+    let display = "brew autoremove".to_string();
+    let jobs = state.jobs.clone();
+    let lock = state.brew_write_lock.clone();
+
+    let _guard = lock.lock_owned().await;
+    let result = run_brew_streaming(&path, args, display, on_event, jobs).await;
+
+    if result.is_ok() {
+        state.invalidate_caches().await;
+    }
+    result
+}
+
 #[tauri::command]
 pub async fn cancel_job(job_id: Uuid, state: State<'_, AppState>) -> Result<(), BrewError> {
     let mut map = state.jobs.lock().await;
@@ -261,4 +321,89 @@ pub async fn cancel_job(job_id: Uuid, state: State<'_, AppState>) -> Result<(), 
         let _ = tx.send(());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn svec(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn install_adopt_is_cask_only() {
+        assert_eq!(
+            install_args("cursor", PackageKind::Cask, false, true),
+            svec(&["install", "--cask", "cursor", "--adopt"])
+        );
+        // Formulae have no on-disk app to adopt → flag is dropped.
+        assert_eq!(
+            install_args("wget", PackageKind::Formula, false, true),
+            svec(&["install", "--formula", "wget"])
+        );
+    }
+
+    #[test]
+    fn install_adopt_and_force_order() {
+        // --adopt before --force; both present when both requested.
+        assert_eq!(
+            install_args("cursor", PackageKind::Cask, true, true),
+            svec(&["install", "--cask", "cursor", "--adopt", "--force"])
+        );
+    }
+
+    #[test]
+    fn install_plain_unchanged() {
+        assert_eq!(
+            install_args("cursor", PackageKind::Cask, false, false),
+            svec(&["install", "--cask", "cursor"])
+        );
+    }
+
+    #[test]
+    fn uninstall_ignore_dependencies_force_remove() {
+        assert_eq!(
+            uninstall_args("gstreamer-runtime", PackageKind::Cask, false, true),
+            svec(&["uninstall", "--cask", "gstreamer-runtime", "--ignore-dependencies"])
+        );
+    }
+
+    #[test]
+    fn uninstall_zap_is_cask_only() {
+        // --zap dropped for a formula; --ignore-dependencies still applies.
+        assert_eq!(
+            uninstall_args("foo", PackageKind::Formula, true, true),
+            svec(&["uninstall", "--formula", "foo", "--ignore-dependencies"])
+        );
+    }
+
+    #[test]
+    fn upgrade_all_greedy() {
+        assert_eq!(upgrade_args(&[], true), svec(&["upgrade", "--greedy"]));
+    }
+
+    #[test]
+    fn upgrade_named_without_greedy() {
+        assert_eq!(
+            upgrade_args(&["wget".to_string()], false),
+            svec(&["upgrade", "wget"])
+        );
+    }
+
+    #[test]
+    fn upgrade_many_greedy() {
+        assert_eq!(
+            upgrade_args(&["a".to_string(), "b".to_string()], true),
+            svec(&["upgrade", "a", "b", "--greedy"])
+        );
+    }
+
+    #[test]
+    fn display_renders_brew_prefix() {
+        assert_eq!(
+            display_for(&install_args("cursor", PackageKind::Cask, false, true)),
+            "brew install --cask cursor --adopt"
+        );
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -148,6 +148,7 @@ pub fn run() {
             brew_update,
             brew_doctor_stream,
             brew_cleanup,
+            brew_autoremove,
             cancel_job,
             brewfile_dump,
             brewfile_install,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -163,11 +163,13 @@ export function brewInstall(
   kind: PackageKind,
   force = false,
   onEvent: (evt: BrewStreamEvent) => void,
+  adopt = false,
 ): Promise<JobResult> {
   return invoke<JobResult>("brew_install", {
     name,
     kind,
     force,
+    adopt,
     onEvent: makeChannel(onEvent),
   });
 }
@@ -177,11 +179,13 @@ export function brewUninstall(
   kind: PackageKind,
   zap: boolean,
   onEvent: (evt: BrewStreamEvent) => void,
+  ignoreDependencies = false,
 ): Promise<JobResult> {
   return invoke<JobResult>("brew_uninstall", {
     name,
     kind,
     zap,
+    ignoreDependencies,
     onEvent: makeChannel(onEvent),
   });
 }
@@ -189,9 +193,11 @@ export function brewUninstall(
 export function brewUpgrade(
   name: string | null,
   onEvent: (evt: BrewStreamEvent) => void,
+  greedy = false,
 ): Promise<JobResult> {
   return invoke<JobResult>("brew_upgrade", {
     name,
+    greedy,
     onEvent: makeChannel(onEvent),
   });
 }
@@ -207,9 +213,24 @@ export function brewUpgrade(
 export function brewUpgradeMany(
   names: string[],
   onEvent: (evt: BrewStreamEvent) => void,
+  greedy = false,
 ): Promise<JobResult> {
   return invoke<JobResult>("brew_upgrade_many", {
     names,
+    greedy,
+    onEvent: makeChannel(onEvent),
+  });
+}
+
+/**
+ * Issue #47 — `brew autoremove`: remove formulae that were pulled in only as
+ * dependencies and are no longer needed. Confirm-gated in the UI; streams like
+ * the other write commands.
+ */
+export function brewAutoremove(
+  onEvent: (evt: BrewStreamEvent) => void,
+): Promise<JobResult> {
+  return invoke<JobResult>("brew_autoremove", {
     onEvent: makeChannel(onEvent),
   });
 }

--- a/src/lib/components/ActivityDrawer.svelte
+++ b/src/lib/components/ActivityDrawer.svelte
@@ -14,11 +14,48 @@
   import { toast } from "$lib/stores/toast.svelte";
   import type { ActivityLine } from "$lib/types";
   import { openReportIssueFromJob } from "$lib/util/reportIssue";
+  import {
+    classifyRecovery,
+    runRecovery,
+    recoveryJobLabel,
+    type RecoveryOption,
+    type RecoveryKind,
+  } from "$lib/util/recovery";
 
   let consoleEl: HTMLDivElement | undefined = $state();
   let autoScroll = $state(true);
 
   let activeJob = $derived(activity.jobs.find((j) => j.jobId === activity.activeJobId) ?? activity.jobs[0]);
+
+  // In-app recovery (#13/#102/#100): when a failed job is a known-recoverable
+  // brew error (install hit "already an App", uninstall hit "required by…"),
+  // offer one-click retry buttons instead of sending the user to Terminal.
+  let recovery = $derived(activeJob ? classifyRecovery(activeJob) : null);
+  let recoveryBusy = $state(false);
+
+  async function runRecoveryChoice(opt: RecoveryOption, choice: RecoveryKind) {
+    if (recoveryBusy) return;
+    recoveryBusy = true;
+    const tmpId = crypto.randomUUID();
+    const flagged =
+      choice === "forceRemove"
+        ? `brew uninstall ${opt.kind === "cask" ? "--cask " : ""}${opt.name} --ignore-dependencies`
+        : `brew install ${opt.kind === "cask" ? "--cask " : ""}${opt.name}${choice === "adopt" ? " --adopt" : " --force"}`;
+    activity.startJob(recoveryJobLabel(opt, choice), tmpId, flagged);
+    try {
+      await runRecovery(opt, choice, (evt) => {
+        if (evt.kind === "started" && evt.jobId !== tmpId) {
+          const j = activity.jobs.find((j) => j.jobId === tmpId);
+          if (j) j.jobId = evt.jobId;
+        }
+        activity.handleEvent(evt);
+      });
+    } catch (e) {
+      toast.error("Couldn't run that action", String(e));
+    } finally {
+      recoveryBusy = false;
+    }
+  }
 
   // ─── Adaptive aria-live for high-volume install streams (security audit §N4).
   //
@@ -287,7 +324,25 @@
               <AlertTriangle size={16} />
               <h3>{failureTitle(activeJob.label)}</h3>
             </div>
-            {#if activeJob.friendlyMessage}
+            {#if recovery}
+              <!-- A recoverable brew failure (#13/#102/#100): offer a one-click
+                   retry with the right flag instead of pointing at Terminal. -->
+              <p>{recovery.reason}</p>
+              <div class="recovery-actions">
+                {#each recovery.choices as choice (choice.kind)}
+                  <button
+                    type="button"
+                    class="recovery-btn {choice.variant}"
+                    disabled={recoveryBusy}
+                    title={choice.hint}
+                    onclick={() => runRecoveryChoice(recovery!, choice.kind)}
+                  >
+                    {choice.label}
+                  </button>
+                {/each}
+              </div>
+              <p class="recovery-hint">{recovery.choices[0].hint}</p>
+            {:else if activeJob.friendlyMessage}
               <!-- A known brew failure with a curated friendly message. -->
               <p>{activeJob.friendlyMessage}</p>
             {:else if activeJob.exitCode != null}
@@ -510,5 +565,49 @@
   .report-btn:focus-visible {
     outline: 2px solid var(--color-focus, var(--color-brand, var(--color-accent)));
     outline-offset: 2px;
+  }
+
+  /* In-app recovery buttons (#13/#102/#100) — paired with the failure card. */
+  .recovery-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+  .recovery-btn {
+    padding: 3px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    font-size: var(--text-body-sm);
+    font-weight: var(--fw-medium);
+    cursor: pointer;
+    transition: background-color var(--motion-duration-fast) var(--motion-ease-out),
+      opacity var(--motion-duration-fast) var(--motion-ease-out);
+  }
+  .recovery-btn:disabled { opacity: 0.55; cursor: wait; }
+  .recovery-btn.primary {
+    background: var(--color-brand);
+    color: var(--color-on-brand, white);
+    border-color: var(--color-brand);
+  }
+  .recovery-btn.primary:hover:not(:disabled) {
+    background: color-mix(in oklch, var(--color-brand) 88%, black);
+  }
+  .recovery-btn.danger {
+    background: transparent;
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+  }
+  .recovery-btn.danger:hover:not(:disabled) {
+    background: color-mix(in oklch, var(--color-danger) 12%, transparent);
+  }
+  .recovery-btn:focus-visible {
+    outline: 2px solid var(--color-focus, var(--color-brand, var(--color-accent)));
+    outline-offset: 2px;
+  }
+  .recovery-hint {
+    margin-top: var(--space-1);
+    font-size: var(--text-caption);
+    color: var(--color-text-muted);
   }
 </style>

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -576,7 +576,7 @@
           if (j) j.jobId = evt.jobId;
         }
         activity.handleEvent(evt);
-      });
+      }, ui.greedyUpgrade);
       if (result.success) {
         toast.success(`Upgraded ${counts.outdated} packages`);
         packages.load(true);

--- a/src/lib/components/PackageDetail.svelte
+++ b/src/lib/components/PackageDetail.svelte
@@ -271,7 +271,7 @@
           if (j) j.jobId = evt.jobId;
         }
         activity.handleEvent(evt);
-      });
+      }, ui.greedyUpgrade);
       if (result.success) {
         toast.success(`Upgraded ${name}`);
         // v0.5.0 — old version gone, new version installed. Drop the old

--- a/src/lib/components/SettingsSectionBrew.svelte
+++ b/src/lib/components/SettingsSectionBrew.svelte
@@ -12,10 +12,14 @@
 
   import { onMount } from "svelte";
 
-  import { brewGetAnalytics, brewSetAnalytics } from "$lib/api";
+  import { brewGetAnalytics, brewSetAnalytics, brewAutoremove } from "$lib/api";
   import { ui } from "$lib/stores/ui.svelte";
+  import { activity } from "$lib/stores/activity.svelte";
   import { isBrewError, brewErrorMessage } from "$lib/types";
+  import type { BrewStreamEvent } from "$lib/types";
   import { toast } from "$lib/stores/toast.svelte";
+  import Button from "./Button.svelte";
+  import DestructiveConfirm from "./DestructiveConfirm.svelte";
 
   let analyticsEnabled = $state<boolean | null>(null);
   let analyticsLoading = $state(false);
@@ -55,6 +59,53 @@
     } finally {
       analyticsLoading = false;
     }
+  }
+
+  // ----- Advanced: autoremove (#47) -----
+
+  let autoremoveConfirmOpen = $state(false);
+  let autoremoveRunning = $state(false);
+
+  /** Run a streaming brew job into the Activity drawer (mirrors Dashboard's
+      `streamJob`): seed a temp job, open the drawer, then reconcile the real
+      job id on the first `started` event. */
+  async function streamJob(
+    label: string,
+    command: string,
+    run: (onEvent: (evt: BrewStreamEvent) => void) => Promise<{ success: boolean }>,
+  ): Promise<boolean> {
+    const tmpId = crypto.randomUUID();
+    activity.startJob(label, tmpId, command);
+    ui.openDrawer();
+    const result = await run((evt) => {
+      if (evt.kind === "started" && evt.jobId !== tmpId) {
+        const j = activity.jobs.find((j) => j.jobId === tmpId);
+        if (j) j.jobId = evt.jobId;
+      }
+      activity.handleEvent(evt);
+    });
+    return result.success;
+  }
+
+  async function runAutoremove() {
+    autoremoveConfirmOpen = false;
+    if (autoremoveRunning) return;
+    autoremoveRunning = true;
+    try {
+      await streamJob("Removing unused dependencies", "brew autoremove", brewAutoremove);
+    } catch (e) {
+      toast.error(
+        "brew autoremove failed to run",
+        isBrewError(e) ? brewErrorMessage(e) : String(e),
+      );
+    } finally {
+      autoremoveRunning = false;
+    }
+  }
+
+  function onAutoremoveClick() {
+    if (ui.confirmDestructive) autoremoveConfirmOpen = true;
+    else void runAutoremove();
   }
 
   onMount(() => {
@@ -112,7 +163,51 @@
       </label>
     </div>
   </section>
+
+  <section class="group">
+    <h3>Advanced</h3>
+    <p class="desc">Extra <code>brew</code> options for power users.</p>
+
+    <div class="row">
+      <label class="toggle">
+        <input
+          type="checkbox"
+          checked={ui.greedyUpgrade}
+          onchange={(e) => ui.setGreedyUpgrade((e.currentTarget as HTMLInputElement).checked)}
+        />
+        <span>Greedy upgrades (include self-updating casks)</span>
+      </label>
+    </div>
+    <p class="desc subtle">
+      Adds <code>--greedy</code> to <code>brew upgrade</code> so casks that
+      update themselves (like Chrome) are upgraded too. Off by default — greedy
+      can churn apps that manage their own updates.
+    </p>
+
+    <div class="row">
+      <Button variant="secondary" disabled={autoremoveRunning} onclick={onAutoremoveClick}>
+        {autoremoveRunning ? "Removing…" : "Autoremove unused dependencies"}
+      </Button>
+    </div>
+    <p class="desc subtle">
+      Runs <code>brew autoremove</code> to uninstall formulae that were installed
+      only as dependencies and are no longer needed by anything.
+    </p>
+  </section>
 </div>
+
+<DestructiveConfirm
+  open={autoremoveConfirmOpen}
+  title="Remove unused dependencies?"
+  confirmLabel="Autoremove"
+  onConfirm={runAutoremove}
+  onCancel={() => (autoremoveConfirmOpen = false)}
+>
+  <p>
+    This runs <code>brew autoremove</code>, which uninstalls formulae that were
+    installed only as dependencies and are no longer required by anything else.
+  </p>
+</DestructiveConfirm>
 
 <style>
   .section { display: flex; flex-direction: column; gap: var(--space-5); max-width: 560px; }
@@ -139,6 +234,11 @@
     background: var(--color-surface-sunken);
     padding: 1px 4px;
     border-radius: var(--radius-sm);
+  }
+  .desc.subtle {
+    font-size: var(--text-caption);
+    color: var(--color-text-muted);
+    margin-top: calc(-1 * var(--space-1));
   }
   .row {
     display: flex;

--- a/src/lib/components/UpgradeModal.svelte
+++ b/src/lib/components/UpgradeModal.svelte
@@ -137,7 +137,7 @@
           if (j) j.jobId = evt.jobId;
         }
         activity.handleEvent(evt);
-      });
+      }, ui.greedyUpgrade);
       if (result.success) {
         toast.success(
           names.length === 1

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -17,6 +17,7 @@ const DETAIL_PANE_WIDTH_KEY = "brew-browser:detail-pane-width";
 const DEFAULT_SECTION_KEY = "brew-browser:default-section";
 const VIBRANCY_MATERIAL_KEY = "brew-browser:vibrancy-material";
 const CONFIRM_DESTRUCTIVE_KEY = "brew-browser:confirm-destructive";
+const GREEDY_UPGRADE_KEY = "brew-browser:greedy-upgrade";
 const ACTIVITY_MAX_JOBS_KEY = "brew-browser:activity:max-jobs";
 const ACTIVITY_MAX_LINES_KEY = "brew-browser:activity:max-lines";
 const SIDEBAR_COLLAPSED_KEY = "brew-browser:sidebar-collapsed";
@@ -115,6 +116,12 @@ class UiStore {
       a confirm dialog. Defaults true; turning it off is a "trust me" mode
       for power users. */
   confirmDestructive: boolean = $state(true);
+
+  /** When true, `brew upgrade` runs with `--greedy` so casks that self-update
+      (`auto_updates` / `version :latest`) are upgraded too (issues #47/#31).
+      Off by default — greedy can churn apps that manage their own updates.
+      Persisted to localStorage; applied by every upgrade path. */
+  greedyUpgrade: boolean = $state(false);
 
   /** Activity persistence caps (Phase 12b). These are the future limits
       for the `activity` store's localStorage mirror. Existing retained
@@ -238,6 +245,19 @@ class UiStore {
       const v = localStorage.getItem(CONFIRM_DESTRUCTIVE_KEY);
       if (v === "0") this.confirmDestructive = false;
       else if (v === "1") this.confirmDestructive = true;
+    } catch { /* ignore */ }
+  }
+
+  setGreedyUpgrade(v: boolean) {
+    this.greedyUpgrade = v;
+    try { localStorage.setItem(GREEDY_UPGRADE_KEY, v ? "1" : "0"); } catch { /* ignore */ }
+  }
+
+  loadGreedyUpgradeFromStorage() {
+    try {
+      const v = localStorage.getItem(GREEDY_UPGRADE_KEY);
+      if (v === "1") this.greedyUpgrade = true;
+      else if (v === "0") this.greedyUpgrade = false;
     } catch { /* ignore */ }
   }
 

--- a/src/lib/util/recovery.test.ts
+++ b/src/lib/util/recovery.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+
+import type { ActivityJob, ActivityLine } from "$lib/types";
+import { classifyRecovery } from "./recovery";
+
+/** Build a failed ActivityJob with the given command + stderr lines. */
+function failed(
+  command: string,
+  stderr: string[],
+  extra: Partial<ActivityJob> = {},
+): ActivityJob {
+  const lines: ActivityLine[] = stderr.map((text) => ({
+    stream: "stderr",
+    text,
+    ts: "2026-06-19T12:00:00.000Z",
+  }));
+  return {
+    jobId: "j1",
+    label: "x",
+    command,
+    startedAt: "2026-06-19T12:00:00.000Z",
+    status: "failed",
+    exitCode: 1,
+    lines,
+    ...extra,
+  };
+}
+
+describe("classifyRecovery — install conflicts (#13/#102)", () => {
+  it("offers Adopt + Overwrite for a cask that already exists", () => {
+    const r = classifyRecovery(
+      failed("brew install --cask google-chrome", [
+        "Error: It seems there is already an App at '/Applications/Google Chrome.app'.",
+      ]),
+    );
+    expect(r).not.toBeNull();
+    expect(r!.action).toBe("install");
+    expect(r!.kind).toBe("cask");
+    expect(r!.name).toBe("google-chrome");
+    expect(r!.choices.map((c) => c.kind)).toEqual(["adopt", "overwrite"]);
+  });
+
+  it("offers only Overwrite for a formula (no --adopt)", () => {
+    const r = classifyRecovery(
+      failed("brew install --formula foo", [
+        "Error: It seems there is already a Binary at '/opt/homebrew/bin/foo'.",
+      ]),
+    );
+    expect(r).not.toBeNull();
+    expect(r!.kind).toBe("formula");
+    expect(r!.choices.map((c) => c.kind)).toEqual(["overwrite"]);
+  });
+});
+
+describe("classifyRecovery — uninstall dependency block (#100)", () => {
+  it("offers Force remove when refused for a dependent", () => {
+    const r = classifyRecovery(
+      failed("brew uninstall --cask gstreamer-runtime", [
+        "Error: Refusing to uninstall gstreamer-runtime",
+        "because it is required by wine-stable, which is currently installed.",
+      ]),
+    );
+    expect(r).not.toBeNull();
+    expect(r!.action).toBe("uninstall");
+    expect(r!.name).toBe("gstreamer-runtime");
+    expect(r!.choices.map((c) => c.kind)).toEqual(["forceRemove"]);
+  });
+});
+
+describe("classifyRecovery — non-recoverable cases", () => {
+  it("returns null for a successful job", () => {
+    expect(
+      classifyRecovery(
+        failed("brew install --cask x", ["whatever"], { status: "succeeded" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no exit code (our spawn failure)", () => {
+    expect(
+      classifyRecovery(failed("brew install --cask x", ["boom"], { exitCode: undefined })),
+    ).toBeNull();
+  });
+
+  it("returns null for an unrelated brew upgrade failure", () => {
+    expect(
+      classifyRecovery(failed("brew upgrade", ["Error: some other failure"])),
+    ).toBeNull();
+  });
+
+  it("returns null for an install failure that isn't an existing-app conflict", () => {
+    expect(
+      classifyRecovery(
+        failed("brew install --cask x", ["Error: Download failed: 404"]),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/util/recovery.ts
+++ b/src/lib/util/recovery.ts
@@ -1,0 +1,159 @@
+/**
+ * recovery.ts — in-app recovery for the two brew failures users hit most and
+ * previously could only fix from Terminal (issues #13/#102, #100).
+ *
+ * `classifyRecovery` is a PURE function of a failed {@link ActivityJob}: it
+ * parses the brew command + stderr to decide whether a one-click retry with a
+ * different flag would succeed, and which choices to offer. `runRecovery`
+ * re-invokes the matching `api.ts` command with that flag, streaming into a
+ * fresh Activity job like any other action.
+ *
+ * The whole point: a user whose install hit "It seems there is already an App
+ * at…" or whose uninstall was "Refusing to uninstall … required by…" gets
+ * Adopt / Overwrite / Force-remove buttons right on the failure card, instead
+ * of being told to drop to a terminal.
+ */
+
+import { brewInstall, brewUninstall } from "$lib/api";
+import type { ActivityJob, BrewStreamEvent, JobResult, PackageKind } from "$lib/types";
+
+export type RecoveryKind = "adopt" | "overwrite" | "forceRemove";
+
+export interface RecoveryChoice {
+  kind: RecoveryKind;
+  /** Button label. */
+  label: string;
+  /** Button styling — danger for overwrite/force, primary for the safe adopt. */
+  variant: "primary" | "danger";
+  /** One-line explanation shown under the buttons / as the button title. */
+  hint: string;
+}
+
+export interface RecoveryOption {
+  /** The command the original (failed) job ran. */
+  action: "install" | "uninstall";
+  name: string;
+  kind: PackageKind;
+  /** A short headline describing what went wrong, in plain language. */
+  reason: string;
+  /** Retry choices, in display order (safest first). */
+  choices: RecoveryChoice[];
+}
+
+/** All log text of a job, joined for pattern-matching (stderr carries the
+ *  brew error; stdout is included as a fallback for older brews). */
+function jobText(job: ActivityJob): string {
+  return job.lines.map((l) => l.text).join("\n");
+}
+
+/** Parse `[brew] <action> [--cask|--formula] <name> [flags…]` from a job's
+ *  display command. Returns null when it isn't a recognizable install/uninstall
+ *  (e.g. `brew upgrade`, `brew autoremove`, a tap update). */
+function parseAction(
+  command: string,
+): { action: "install" | "uninstall"; name: string; kind: PackageKind } | null {
+  const toks = command.trim().split(/\s+/);
+  if (toks[0] === "brew") toks.shift();
+  const action = toks[0];
+  if (action !== "install" && action !== "uninstall") return null;
+  const kind: PackageKind = toks.includes("--cask") ? "cask" : "formula";
+  // The package name is the first token after the action that isn't a flag.
+  const name = toks.slice(1).find((t) => !t.startsWith("-"));
+  if (!name) return null;
+  return { action, name, kind };
+}
+
+// brew's "already installed outside Homebrew" message. Matches casks ("App")
+// and the rarer formula/binary variants, across brew versions.
+const ALREADY_EXISTS = /it seems there is already an? (app|application|binary|file) at|already an app at/i;
+// brew's dependency-protection refusal on uninstall.
+const REQUIRED_BY = /refusing to uninstall|because it('s| is)? +(still +)?required by|is required by/i;
+
+/**
+ * Decide whether a failed job can be retried in-app, and how. Pure — safe to
+ * call from a `$derived`. Returns null for anything not recoverable (success,
+ * cancel, no exit code = our own spawn failure, or an unrecognized error).
+ */
+export function classifyRecovery(job: ActivityJob): RecoveryOption | null {
+  // Only brew-ran-and-failed jobs are recoverable. No exit code = an IPC/spawn
+  // failure (our bug) — that path keeps the "Report" button, not a retry.
+  if (job.status !== "failed" || job.exitCode == null) return null;
+
+  const parsed = parseAction(job.command);
+  if (!parsed) return null;
+  const text = jobText(job);
+
+  if (parsed.action === "install" && ALREADY_EXISTS.test(text)) {
+    const choices: RecoveryChoice[] = [];
+    // --adopt only exists for casks; it's the safe, recommended fix.
+    if (parsed.kind === "cask") {
+      choices.push({
+        kind: "adopt",
+        label: "Adopt existing",
+        variant: "primary",
+        hint: "Let Homebrew manage the copy already on your Mac (keeps it in place).",
+      });
+    }
+    choices.push({
+      kind: "overwrite",
+      label: "Overwrite",
+      variant: "danger",
+      hint: "Replace the existing copy with a fresh Homebrew install.",
+    });
+    return {
+      ...parsed,
+      reason: `${parsed.name} is already installed outside Homebrew.`,
+      choices,
+    };
+  }
+
+  if (parsed.action === "uninstall" && REQUIRED_BY.test(text)) {
+    return {
+      ...parsed,
+      reason: `${parsed.name} is still required by another installed package.`,
+      choices: [
+        {
+          kind: "forceRemove",
+          label: "Force remove",
+          variant: "danger",
+          hint: "Remove it anyway, ignoring packages that depend on it.",
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Re-run the original command with the flag the chosen recovery implies.
+ * Streams through `onEvent` exactly like the first attempt.
+ */
+export function runRecovery(
+  opt: RecoveryOption,
+  choice: RecoveryKind,
+  onEvent: (evt: BrewStreamEvent) => void,
+): Promise<JobResult> {
+  switch (choice) {
+    case "adopt":
+      // brewInstall(name, kind, force, onEvent, adopt)
+      return brewInstall(opt.name, opt.kind, false, onEvent, true);
+    case "overwrite":
+      return brewInstall(opt.name, opt.kind, true, onEvent, false);
+    case "forceRemove":
+      // brewUninstall(name, kind, zap, onEvent, ignoreDependencies)
+      return brewUninstall(opt.name, opt.kind, false, onEvent, true);
+  }
+}
+
+/** Human label for the Activity job a recovery spawns. */
+export function recoveryJobLabel(opt: RecoveryOption, choice: RecoveryKind): string {
+  switch (choice) {
+    case "adopt":
+      return `Adopting ${opt.name}`;
+    case "overwrite":
+      return `Reinstalling ${opt.name}`;
+    case "forceRemove":
+      return `Force-removing ${opt.name}`;
+  }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
     ui.loadDefaultSectionFromStorage();
     ui.loadVibrancyMaterialFromStorage();
     ui.loadConfirmDestructiveFromStorage();
+    ui.loadGreedyUpgradeFromStorage();
     ui.loadActivitySettingsFromStorage();
     ui.loadSidebarCollapsedFromStorage();
     activity.hydrate();


### PR DESCRIPTION
Closes the "users can't drive brew flags from the GUI" gap — a failed install/uninstall or a power-user option no longer means dropping to Terminal.

## Reactive recovery (#98 reactive, #13, #102, #100)
When a brew command fails in a recoverable way, the Activity **failure card** now offers a one-click retry with the right flag instead of "run it in Terminal":
- install hit **"It seems there is already an App at…"** → **Adopt existing** (cask `--adopt`) + **Overwrite** (`--force`)  — #13, #102
- uninstall **"Refusing to uninstall … required by…"** → **Force remove** (`--ignore-dependencies`)  — #100

Classification is a pure, unit-tested function in both shells (`src/lib/util/recovery.ts`, `BrewRecovery.swift`).

## Advanced options — Settings → Brew (#47)
- **Greedy upgrades** toggle (persisted; adds `--greedy` so self-updating casks are included) — wired into every upgrade path (Dashboard / per-package / curated).
- **Autoremove** action (`brew autoremove`, confirm-gated) to remove no-longer-needed dependencies.

## Backend
Pure, unit-tested argv builders in both shells gain `adopt`/`force`, `ignore-dependencies`, and `greedy`; new `autoremove` command. **All flags default off — behavior is unchanged until the user opts in.**

## Tests
cargo **+9** arg-builders · vitest **+7** recovery · swift **+9** (BrewArgs + BrewRecovery). Full suites green (cargo 658, swift 154, vitest 42, svelte-check clean).

## Not included
**#98's proactive discovery** (scan `/Applications`, match the cask catalog, "Discovered" surface) is **not** in this PR — only the reactive adopt-on-conflict path. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)