### PR TITLE
feat: pin/unpin packages in the GUI (#90) + Library panel refresh

### DIFF
--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -70,6 +70,10 @@ struct LibraryRow: Identifiable, Hashable, Sendable {
     /// or the package isn't deprecated/disabled (no badge then). Feature #2.
     let deprecation: DeprecationStatus
 
+    /// Whether the package is pinned (held back from `brew upgrade`). Drives the
+    /// row's "Pinned" badge (#90). From `InstalledPackage.pinned`.
+    let pinned: Bool
+
     /// Comparable proxy for sorting the Outdated column (`Bool` isn't
     /// `Comparable`). Outdated rows sort high so descending surfaces them first.
     var outdatedRank: Int { isOutdated ? 1 : 0 }
@@ -216,7 +220,8 @@ public final class AppModel {
                 summary: showSummary ? (entry?.summary ?? "") : "",
                 maxSeverity: (vuln?.total ?? 0) > 0 ? vuln?.maxSeverity : nil,
                 vulnCount: vuln?.total ?? 0,
-                deprecation: deprecationStatus(pkg.name, pkg.kind)
+                deprecation: deprecationStatus(pkg.name, pkg.kind),
+                pinned: pkg.pinned
             )
         }
     }
@@ -1227,7 +1232,7 @@ public final class AppModel {
     var totalPackages: Int { formulaCount + caskCount }
 
     /// First 5 outdated packages for the Dashboard preview list.
-    var outdatedPreview: [OutdatedPackage] { Array(outdated.prefix(5)) }
+    var outdatedPreview: [OutdatedPackage] { Array(outdated.lazy.filter { !$0.pinned }.prefix(5)) }
 
     /// Total bytes across all storage categories.
     var storageTotalBytes: Int64 { storage.reduce(0) { $0 + $1.bytes } }
@@ -1291,7 +1296,12 @@ public final class AppModel {
     func loadOutdated() async {
         outdatedLoading = true
         outdated = (try? await brew.outdatedPackages()) ?? []
-        outdatedCount = outdated.count
+        // `brew outdated --json` still lists pinned packages (flagged
+        // `pinned: true`), but they're intentionally held back (#90) and brew
+        // upgrade skips them — so the nag count (sidebar badge, Dashboard
+        // "updates available", "Upgrade all (N)") counts only upgradable ones.
+        // The Library's Outdated filter still shows pinned rows (badged).
+        outdatedCount = outdated.lazy.filter { !$0.pinned }.count
         outdatedLoading = false
     }
 
@@ -1842,6 +1852,23 @@ public final class AppModel {
         if greedy { args.append("--greedy") }
         let ok = await startJob("Upgrading \(pkg.name)", args: args, startedAt: Date().timeIntervalSince1970)
         if ok, let pkg = detailPackage { await loadDetail(pkg) }
+    }
+
+    /// Pin/unpin the detail package via `brew pin`/`unpin` (#90). Quiet and
+    /// non-streaming — an instant flag flip, so it toasts success/failure
+    /// rather than spawning an Activity job. On success `refresh()` reloads the
+    /// installed + outdated lists (so the honest update count and Library badge
+    /// re-derive) and the detail reloads so the footer button flips.
+    func setPinnedDetail(_ pinned: Bool) async {
+        guard let pkg = detailPackage else { return }
+        do {
+            try await brew.setPinned(pkg.name, kind: pkg.kind, pinned: pinned)
+            pushToast(.success, pinned ? "Pinned \(pkg.name)" : "Unpinned \(pkg.name)")
+            await refresh()
+            if let pkg = detailPackage { await loadDetail(pkg) }
+        } catch {
+            pushToast(.error, pinned ? "Pin failed" : "Unpin failed", error.localizedDescription)
+        }
     }
 
     /// Uninstall the detail package. `ignoreDependencies` adds

--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -38,6 +38,7 @@ enum LibraryFilter: String, CaseIterable, Identifiable, Hashable {
     case formulae   = "Formulae"
     case casks      = "Casks"
     case outdated   = "Outdated"
+    case pinned     = "Pinned"
     case manual     = "Manual"
     case dependency = "Dependency"
     case vulnerable = "Vulnerable"
@@ -198,6 +199,7 @@ public final class AppModel {
             case .formulae:   guard pkg.kind == .formula else { return nil }
             case .casks:      guard pkg.kind == .cask else { return nil }
             case .outdated:   guard outdatedSet.contains(pkg.name) else { return nil }
+            case .pinned:     guard pkg.pinned else { return nil }
             // Manual = installed on request; Dependency = a formula NOT on request
             // (casks are always on-request, so never appear under Dependency) (#3).
             case .manual:     guard pkg.installedOnRequest else { return nil }
@@ -238,6 +240,7 @@ public final class AppModel {
         case .formulae:   return installed.lazy.filter { $0.kind == .formula }.count
         case .casks:      return installed.lazy.filter { $0.kind == .cask }.count
         case .outdated:   return outdatedNames.count
+        case .pinned:     return installed.lazy.filter { $0.pinned }.count
         case .manual:     return installed.lazy.filter { $0.installedOnRequest }.count
         case .dependency: return installed.lazy.filter { $0.kind == .formula && !$0.installedOnRequest }.count
         case .vulnerable: return vulnerableCount
@@ -1271,14 +1274,16 @@ public final class AppModel {
         }
         async let leaves = try? brew.countLeaves()
         async let onRequest = try? brew.countOnRequest()
-        async let pinned = try? brew.countPinned()
         async let ver = brew.version()
         async let pfx = brew.prefix()
         async let services = brew.countRunningServices()
 
         leavesCount = await leaves ?? 0
         onRequestCount = await onRequest ?? 0
-        pinnedCount = await pinned ?? 0
+        // Count pins from the installed list (its top-level `pinned` covers
+        // formulae AND casks) rather than `brew list --pinned`, which only
+        // reports pinned formulae and would undercount pinned casks (#90).
+        pinnedCount = installed.lazy.filter { $0.pinned }.count
         brewVersion = await ver
         brewPrefix = await pfx
         runningServices = await services

--- a/native/Sources/BrewBrowserKit/BrewService.swift
+++ b/native/Sources/BrewBrowserKit/BrewService.swift
@@ -20,6 +20,14 @@ struct InstalledPackage: Identifiable, Hashable, Sendable {
     /// `list --versions` constructors stay valid before tagging. Feature #3.
     var installedOnRequest: Bool = false
 
+    /// Whether brew has this package pinned (`brew pin`) — held back from
+    /// `brew upgrade` (including `--greedy`). Read from the top-level `pinned`
+    /// flag in `brew info --installed --json=v2` (both formulae and casks carry
+    /// it in current Homebrew). Drives the Library "Pinned" badge and keeps a
+    /// pinned package out of the honest "updates available" count (#90).
+    /// Defaults `false` so the lightweight nav constructors stay valid.
+    var pinned: Bool = false
+
     enum Kind: String, Sendable { case formula, cask }
 }
 
@@ -33,9 +41,10 @@ struct OutdatedPackage: Identifiable, Hashable, Sendable {
     /// formula vs cask — taken from the `brew outdated --json=v2` array the row
     /// came from, so the Dashboard pill + detail open use the right kind.
     let kind: InstalledPackage.Kind
-    /// `pinned` from `brew outdated --json=v2` (formulae only; casks can't be
-    /// pinned). Pinned formulae are excluded from the curated upgrade sheet
-    /// because brew refuses to upgrade them. Mirrors the Tauri `Package.pinned`.
+    /// `pinned` from `brew outdated --json=v2` (both formulae and casks in
+    /// current Homebrew). `brew outdated --json` still *lists* pinned packages
+    /// with `pinned: true`, so they're excluded from the curated upgrade sheet
+    /// and the honest update count (#90). Mirrors the Tauri `Package.pinned`.
     var pinned: Bool = false
 }
 
@@ -142,6 +151,18 @@ enum BrewArgs {
         args.append(name)
         if zap && kind == .cask { args.append("--zap") }
         if ignoreDependencies { args.append("--ignore-dependencies") }
+        return args
+    }
+
+    /// `brew pin [--cask] <name>` / `brew unpin [--cask] <name>`. Pinning holds
+    /// a package back from `brew upgrade` (including `--greedy`) — the in-app
+    /// "stop nagging me about this one" hold for #90/#134. Current Homebrew
+    /// pins both formulae and casks, so the `--cask` flag disambiguates a name
+    /// that exists as both. `pinned == true` pins; `false` unpins.
+    static func setPinned(_ name: String, kind: InstalledPackage.Kind, pinned: Bool) -> [String] {
+        var args = [pinned ? "pin" : "unpin"]
+        if kind == .cask { args.append("--cask") }
+        args.append(name)
         return args
     }
 }
@@ -400,7 +421,9 @@ struct BrewService: Sendable {
                 ?? ((o["versions"] as? [String: Any])?["stable"] as? String)
                 ?? "—"
             let onRequest = first?["installed_on_request"] as? Bool ?? false
-            return InstalledPackage(name: name, version: version, kind: .formula, installedOnRequest: onRequest)
+            let pinned = o["pinned"] as? Bool ?? false
+            return InstalledPackage(name: name, version: version, kind: .formula,
+                                    installedOnRequest: onRequest, pinned: pinned)
         }
 
         let casks = (root["casks"] as? [[String: Any]] ?? []).compactMap { o -> InstalledPackage? in
@@ -409,7 +432,9 @@ struct BrewService: Sendable {
             let version = installed
                 ?? o["version"] as? String
                 ?? "—"
-            return InstalledPackage(name: token, version: version, kind: .cask, installedOnRequest: true)
+            let pinned = o["pinned"] as? Bool ?? false
+            return InstalledPackage(name: token, version: version, kind: .cask,
+                                    installedOnRequest: true, pinned: pinned)
         }
 
         return (formulae + casks)
@@ -760,7 +785,10 @@ extension BrewService {
             tap: o["tap"] as? String,
             caveats: o["caveats"] as? String,
             outdated: o["outdated"] as? Bool ?? false,
-            pinned: false,
+            // Casks pin too in current Homebrew — read the real flag rather
+            // than hardcoding false, so the detail Pin/Unpin button reflects
+            // actual state (#90).
+            pinned: o["pinned"] as? Bool ?? false,
             dependencies: [],
             buildDependencies: [],
             conflictsWith: [],
@@ -787,6 +815,13 @@ extension BrewService {
         if kind == .cask { args.append("--cask") }
         args.append(name)
         _ = try await runCapture(args)
+    }
+
+    /// `brew pin`/`unpin [--cask] <name>` — runs to completion, throws on
+    /// failure. Instant metadata flip (no streaming), so it goes through
+    /// `runCapture` like the other short write commands (#90).
+    func setPinned(_ name: String, kind: InstalledPackage.Kind, pinned: Bool) async throws {
+        _ = try await runCapture(BrewArgs.setPinned(name, kind: kind, pinned: pinned))
     }
 
     // MARK: - Homebrew analytics (Settings → Brew)

--- a/native/Sources/BrewBrowserKit/BrewService.swift
+++ b/native/Sources/BrewBrowserKit/BrewService.swift
@@ -494,9 +494,6 @@ struct BrewService: Sendable {
         }
     }
 
-    /// Pinned formulae (held back from upgrade). Mirrors the "N pinned" chip.
-    func countPinned() async throws -> Int { try await lineCount(["list", "--pinned"]) }
-
     /// Count of running brew services (`brew services list`, status "started"/
     /// "scheduled"). Powers the Services sidebar badge. Best-effort: 0 on error.
     func countRunningServices() async -> Int {

--- a/native/Sources/BrewBrowserKit/ContentView.swift
+++ b/native/Sources/BrewBrowserKit/ContentView.swift
@@ -462,6 +462,13 @@ struct LibraryView: View {
                     if let badge = row.deprecation.badge {
                         DeprecationBadge(kind: badge, reason: row.deprecation.activeReason)
                     }
+                    if row.pinned {
+                        // Pinned badge (#90) — held back from brew upgrade.
+                        Image(systemName: "pin.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .help("Pinned — held back from brew upgrade")
+                    }
                 }
                 if !row.friendlyName.isEmpty {
                     Text(row.friendlyName).font(.caption).foregroundStyle(.secondary).lineLimit(1)

--- a/native/Sources/BrewBrowserKit/ContentView.swift
+++ b/native/Sources/BrewBrowserKit/ContentView.swift
@@ -300,6 +300,8 @@ struct LibraryView: View {
                     Divider()
                     table
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    Divider()
+                    libraryCountBar
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
@@ -326,7 +328,9 @@ struct LibraryView: View {
     private var filterBar: some View {
         Picker("Filter", selection: $model.libraryFilter) {
             ForEach(model.availableLibraryFilters) { f in
-                Text("\(f.rawValue) (\(model.libraryFilterCount(f)))").tag(f)
+                // Counts moved to the bottom status bar (`libraryCountBar`) —
+                // the tabs stay clean labels.
+                Text(f.rawValue).tag(f)
             }
         }
         .pickerStyle(.segmented)
@@ -335,6 +339,30 @@ struct LibraryView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    /// Bottom status tally — the same subtle style as the Services header
+    /// (`ServicesView.headerBar`), moved to the foot of the Library. It replaces
+    /// the per-tab counts removed above. Leads with the count of the ACTIVE
+    /// filter (the number of rows currently shown, so it also reflects the
+    /// search box), labelled by that filter; then the standing outdated + pinned
+    /// stats — skipping whichever the lead already names to avoid "7 outdated ·
+    /// 7 outdated". `pinned` counts formulae + casks (#90).
+    private var libraryCountBar: some View {
+        let f = model.libraryFilter
+        let shown = model.sortedLibraryRows.count
+        let noun = f == .all ? (shown == 1 ? "package" : "packages") : f.rawValue.lowercased()
+        var parts = ["\(shown) \(noun)"]
+        if f != .outdated { parts.append("\(model.libraryFilterCount(.outdated)) outdated") }
+        if f != .pinned   { parts.append("\(model.pinnedCount) pinned") }
+        return HStack(spacing: 0) {
+            Text(parts.joined(separator: " · "))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 
     // Removable chip showing the active category filter (set by tapping a

--- a/native/Sources/BrewBrowserKit/PackageDetailView.swift
+++ b/native/Sources/BrewBrowserKit/PackageDetailView.swift
@@ -754,6 +754,20 @@ struct PackageDetailView: View {
             // during the post-install detail refresh.
             if info != nil || isInstalled {
                 if isInstalled {
+                    // Pin/Unpin (#90) — held-back packages drop out of the
+                    // update count. State from the loaded info; casks pin too.
+                    Button {
+                        Task { await model.setPinnedDetail(!(info?.pinned ?? false)) }
+                    } label: {
+                        Label(info?.pinned == true ? "Unpin" : "Pin",
+                              systemImage: info?.pinned == true ? "pin.slash" : "pin")
+                    }
+                    .disabled(model.actionRunning)
+                    .help(info?.pinned == true
+                        ? "Unpin — let brew upgrade update this again"
+                        : (model.detailPackage?.kind == .cask
+                            ? "Pin — hold back from brew upgrade. A cask that self-updates may still update on its own."
+                            : "Pin — hold back from brew upgrade"))
                     if info?.isOutdated == true {
                         Button {
                             Task { await model.upgradeDetail(greedy: LocalPrefs.shared.greedyUpgrade) }

--- a/native/Tests/BrewBrowserKitTests/BrewOutputParsingTests.swift
+++ b/native/Tests/BrewBrowserKitTests/BrewOutputParsingTests.swift
@@ -314,6 +314,18 @@ struct BrewArgsTests {
         #expect(BrewArgs.uninstall("foo", kind: .formula, zap: true, ignoreDependencies: true)
             == ["uninstall", "foo", "--ignore-dependencies"])
     }
+
+    @Test func pinFormulaAndCask() {
+        #expect(BrewArgs.setPinned("wget", kind: .formula, pinned: true) == ["pin", "wget"])
+        // Casks pin too in current Homebrew — the actual #90/#134 case.
+        #expect(BrewArgs.setPinned("google-chrome", kind: .cask, pinned: true)
+            == ["pin", "--cask", "google-chrome"])
+    }
+
+    @Test func unpinUsesUnpinVerb() {
+        #expect(BrewArgs.setPinned("google-chrome", kind: .cask, pinned: false)
+            == ["unpin", "--cask", "google-chrome"])
+    }
 }
 
 @Suite("BrewRecovery")

--- a/native/Tests/BrewBrowserKitTests/ManualDependencyFilterTests.swift
+++ b/native/Tests/BrewBrowserKitTests/ManualDependencyFilterTests.swift
@@ -118,6 +118,33 @@ struct InstalledPackageOnRequestTests {
         #expect(byName["docker-desktop"]?.installedOnRequest == true)
     }
 
+    @Test func installedInfoV2ReadsPinnedForFormulaeAndCasks() throws {
+        // `brew info --installed --json=v2` exposes a top-level `pinned` bool on
+        // both formulae and casks; parseInstalledInfoV2 must surface it so the
+        // Library badge + honest update count work (#90). Absent = false.
+        let raw = """
+        {
+          "formulae": [
+            { "name": "php@8.4", "pinned": true,
+              "installed": [ { "version": "8.4.1", "installed_on_request": true } ] },
+            { "name": "wget",
+              "installed": [ { "version": "1.25.0", "installed_on_request": true } ] }
+          ],
+          "casks": [
+            { "token": "google-chrome", "version": "1.0", "installed": "1.0", "pinned": true },
+            { "token": "rectangle", "version": "0.84", "installed": "0.84" }
+          ]
+        }
+        """
+        let byName = Dictionary(uniqueKeysWithValues:
+            try BrewService.parseInstalledInfoV2(raw).map { ($0.name, $0) })
+
+        #expect(byName["php@8.4"]?.pinned == true)
+        #expect(byName["wget"]?.pinned == false)        // absent → false
+        #expect(byName["google-chrome"]?.pinned == true) // casks pin too
+        #expect(byName["rectangle"]?.pinned == false)
+    }
+
     @MainActor
     @Test func tapQualifiedTokensMatchBareInstalledPackage() {
         let m = AppModel()

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -10,7 +10,7 @@ use tauri::ipc::Channel;
 use tauri::State;
 use uuid::Uuid;
 
-use crate::brew::exec::run_brew_streaming;
+use crate::brew::exec::{run_brew_capture, run_brew_streaming};
 use crate::commands::info::validate_package_name;
 use crate::error::BrewError;
 use crate::state::AppState;
@@ -70,6 +70,16 @@ fn upgrade_args(names: &[String], greedy: bool) -> Vec<String> {
         args.push("--greedy".to_string());
     }
     args
+}
+
+/// `brew pin <kind> <name>` / `brew unpin <kind> <name>`. Pinning holds a
+/// package back so `brew upgrade` (including `--greedy`) skips it — the in-app
+/// "stop nagging me about this one" hold for #90/#134. Current Homebrew pins
+/// both formulae and casks, so the kind flag disambiguates a name that exists
+/// as both. `pinned == true` pins; `false` unpins.
+fn pin_args(name: &str, kind: PackageKind, pinned: bool) -> Vec<String> {
+    let verb = if pinned { "pin" } else { "unpin" };
+    vec![verb.to_string(), kind_flag(kind).to_string(), name.to_string()]
 }
 
 /// User-facing command string for the Activity log, derived from the argv.
@@ -310,6 +320,36 @@ pub async fn brew_autoremove(
     result
 }
 
+/// `brew pin`/`unpin` a single package (issue #90, folds in #134). Fast and
+/// non-streaming — pin is an instant metadata flip with trivial output, so it
+/// runs through `run_brew_capture` and returns once done rather than spawning a
+/// tracked Activity job. Still serialized behind the write lock (so it can't
+/// race a concurrent upgrade) and invalidates caches on success so the pinned
+/// badge and the honest "updates available" count re-derive from fresh
+/// `brew info`/`brew outdated` data. A non-zero exit (e.g. package not
+/// installed) surfaces as a friendly `BrewExitNonZero`, same as the other
+/// write commands.
+#[tauri::command]
+pub async fn brew_set_pinned(
+    name: String,
+    kind: PackageKind,
+    pinned: bool,
+    state: State<'_, AppState>,
+) -> Result<(), BrewError> {
+    validate_package_name(&name)?;
+    let path = state.require_brew_path().await?;
+
+    let args = pin_args(&name, kind, pinned);
+    let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let display = display_for(&args);
+    let lock = state.brew_write_lock.clone();
+
+    let _guard = lock.lock_owned().await;
+    run_brew_capture(&path, &str_args, &display).await?;
+    state.invalidate_caches().await;
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn cancel_job(job_id: Uuid, state: State<'_, AppState>) -> Result<(), BrewError> {
     let mut map = state.jobs.lock().await;
@@ -404,6 +444,27 @@ mod tests {
         assert_eq!(
             display_for(&install_args("cursor", PackageKind::Cask, false, true)),
             "brew install --cask cursor --adopt"
+        );
+    }
+
+    #[test]
+    fn pin_formula_and_cask() {
+        assert_eq!(
+            pin_args("wget", PackageKind::Formula, true),
+            svec(&["pin", "--formula", "wget"])
+        );
+        // Casks pin too in current Homebrew — the actual #90/#134 case.
+        assert_eq!(
+            pin_args("google-chrome", PackageKind::Cask, true),
+            svec(&["pin", "--cask", "google-chrome"])
+        );
+    }
+
+    #[test]
+    fn unpin_uses_unpin_verb() {
+        assert_eq!(
+            pin_args("google-chrome", PackageKind::Cask, false),
+            svec(&["unpin", "--cask", "google-chrome"])
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,6 +181,7 @@ pub fn run() {
             brew_doctor_stream,
             brew_cleanup,
             brew_autoremove,
+            brew_set_pinned,
             cancel_job,
             brewfile_dump,
             brewfile_install,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -243,6 +243,21 @@ export function brewUpdate(
   });
 }
 
+/**
+ * Issue #90 (folds in #134) — `brew pin`/`unpin` a package so `brew upgrade`
+ * (including `--greedy`) skips it. Non-streaming: pin is an instant flip, so
+ * this resolves once done rather than emitting Activity events. `pinned=true`
+ * pins, `false` unpins. On success the backend invalidates its caches, so
+ * callers should reload the package list to pick up the new pin state.
+ */
+export function brewSetPinned(
+  name: string,
+  kind: PackageKind,
+  pinned: boolean,
+): Promise<void> {
+  return invoke<void>("brew_set_pinned", { name, kind, pinned });
+}
+
 /** Issue #80 — stream `brew doctor` diagnostics into the Activity drawer.
  *  (Distinct from the onboarding `brewDoctor()` env probe above.) A non-zero
  *  exit from advisories is reported by the backend as effective-success. */

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -351,7 +351,9 @@
   /** Counts derived from the loaded package list. All zero until `load` completes. */
   let counts = $derived.by(() => {
     const all = packages.all;
-    const outdated = packages.outdated.length;
+    // "updates available" counts only upgradable packages — pinned ones are
+    // held back (#90) and brew upgrade skips them, so they don't nag here.
+    const outdated = packages.outdatedUpgradable.length;
     const formulae = packages.formulae.length;
     const casks = packages.casks.length;
     const pinned = all.filter((p) => p.pinned).length;
@@ -558,9 +560,10 @@
     discover.selectOnly(slug);
   }
 
-  /** First 5 outdated packages, sorted alphabetically for stable display. */
+  /** First 5 *upgradable* packages, sorted alphabetically for stable display.
+   *  Pinned packages are held back (#90) and don't appear in the updates card. */
   let outdatedPreview = $derived.by(() =>
-    [...packages.outdated].sort((a, b) => a.name.localeCompare(b.name)).slice(0, 5),
+    [...packages.outdatedUpgradable].sort((a, b) => a.name.localeCompare(b.name)).slice(0, 5),
   );
 
   let upgradeAllRunning = $state(false);

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -38,8 +38,8 @@
   // Linux: casks don't exist there, so the Casks pill (always 0) is dropped.
   let libraryFilters = $derived.by<LibraryFilter[]>(() => {
     const base: LibraryFilter[] = vulnerabilities.enabled
-      ? ["all", "formulae", "casks", "outdated", "manual", "dependency", "vulnerable"]
-      : ["all", "formulae", "casks", "outdated", "manual", "dependency"];
+      ? ["all", "formulae", "casks", "outdated", "pinned", "manual", "dependency", "vulnerable"]
+      : ["all", "formulae", "casks", "outdated", "pinned", "manual", "dependency"];
     return base.filter((f) => !(isLinux && f === "casks"));
   });
 
@@ -53,6 +53,8 @@
       case "formulae": base = packages.formulae; break;
       case "casks":    base = packages.casks; break;
       case "outdated": base = packages.outdated; break;
+      // #90 — pinned packages (held back from brew upgrade); formulae + casks.
+      case "pinned":   base = packages.all.filter((p) => p.pinned); break;
       // Feature #3 — Manual = installed_on_request; Dependency = installed
       // as a dependency and NOT on request (so a both-flags-true package
       // counts as Manual only, never Dependency). Predicates are shared
@@ -123,6 +125,20 @@
     return arr;
   });
 
+  // Bottom status bar text. Leads with the count of the ACTIVE filter (the
+  // rows currently shown, so it reflects the search box too), labelled by the
+  // filter; then the standing outdated + pinned stats — skipping whichever the
+  // lead already names so we don't print "7 outdated · 7 outdated". #90.
+  let countBar = $derived.by(() => {
+    const shown = sorted.length;
+    const f = library.filter;
+    const noun = f === "all" ? (shown === 1 ? "package" : "packages") : f;
+    const parts = [`${shown} ${noun}`];
+    if (f !== "outdated") parts.push(`${packages.outdated.length} outdated`);
+    if (f !== "pinned") parts.push(`${packages.all.filter((p) => p.pinned).length} pinned`);
+    return parts.join(" · ");
+  });
+
   function changeSort(key: string) {
     const k = key as SortKey;
     if (sortKey === k) {
@@ -156,7 +172,8 @@
        keeps the install count + filter input + Refresh button. -->
   <header class="panel-head" data-tauri-drag-region>
     <div class="head-left">
-      <span class="count text-muted">{packages.all.length} installed</span>
+      <!-- Install count relocated to the bottom status bar (`count-bar`),
+           alongside the outdated + pinned tallies (#90). -->
     </div>
     <div class="head-right" data-tauri-drag-region="false">
       <Input bind:value={query} placeholder="Filter…" variant="search" size="sm" ariaLabel="Filter installed packages" />
@@ -172,15 +189,8 @@
   <div class="filter-bar">
     <div class="pillgroup" role="tablist" aria-label="Type filter">
       {#each libraryFilters as f (f)}
-        {@const count = f === "outdated"
-          ? packages.outdated.length
-          : f === "manual"
-            ? packages.all.filter(isManual).length
-            : f === "dependency"
-              ? packages.all.filter(isDependencyOnly).length
-              : f === "vulnerable"
-                ? vulnerabilities.severityCounts.vulnerablePackages
-                : null}
+        <!-- Counts moved to the bottom status bar (`count-bar`) — the tabs
+             stay clean labels. -->
         <button
           role="tab"
           aria-selected={library.filter === f}
@@ -188,9 +198,6 @@
           onclick={() => library.setFilter(f)}
         >
           {f === "all" ? "All" : f[0].toUpperCase() + f.slice(1)}
-          {#if count !== null && count > 0}
-            <span class="filter-count" class:filter-count-danger={f === "vulnerable"}>{count}</span>
-          {/if}
         </button>
       {/each}
     </div>
@@ -287,6 +294,11 @@
       </div>
     {/if}
   </div>
+
+  <!-- Bottom status tally — mirrors the Services header style, at the foot of
+       the Library. Replaces the per-tab counts + the old header "N installed".
+       Leads with the active filter's count (see `countBar`). #90. -->
+  <footer class="count-bar text-muted">{countBar}</footer>
 </section>
 
 <style>
@@ -313,7 +325,12 @@
   @media (max-width: 1000px) {
     .refresh-wrap { display: none; }
   }
-  .count { font-size: var(--text-body-sm); }
+  .count-bar {
+    flex-shrink: 0;
+    padding: var(--space-2) var(--space-4);
+    border-top: 1px solid var(--color-border);
+    font-size: var(--text-body-sm);
+  }
 
   .filter-bar {
     padding: var(--space-2) var(--space-4);
@@ -347,23 +364,6 @@
     color: var(--color-text-primary);
     box-shadow: var(--shadow-xs);
   }
-  .filter-count {
-    display: inline-flex;
-    align-items: center;
-    height: 14px;
-    padding: 0 4px;
-    border-radius: var(--radius-full);
-    background: var(--color-brand);
-    color: var(--color-text-inverse);
-    font-size: 10px;
-    font-weight: var(--fw-semibold);
-  }
-  /* v0.5.0 — danger-toned count for the Vulnerable pill so the
-     severity signal carries through even before the user clicks. */
-  .filter-count-danger {
-    background: var(--color-danger);
-  }
-
   .chip-bar {
     display: flex;
     flex-wrap: wrap;

--- a/src/lib/components/PackageDetail.svelte
+++ b/src/lib/components/PackageDetail.svelte
@@ -8,6 +8,8 @@
   import Trash2 from "@lucide/svelte/icons/trash-2";
   import RefreshCcw from "@lucide/svelte/icons/refresh-ccw";
   import ArrowUpCircle from "@lucide/svelte/icons/arrow-up-circle";
+  import Pin from "@lucide/svelte/icons/pin";
+  import PinOff from "@lucide/svelte/icons/pin-off";
 
   import Pill from "./Pill.svelte";
   import Button from "./Button.svelte";
@@ -44,7 +46,7 @@
   import ShieldCheck from "@lucide/svelte/icons/shield-check";
   import ShieldAlert from "@lucide/svelte/icons/shield-alert";
   import Shield from "@lucide/svelte/icons/shield";
-  import { brewInfo, brewInstall, brewUninstall, brewUpgrade, appVersion, catalogReverseDependents } from "$lib/api";
+  import { brewInfo, brewInstall, brewUninstall, brewUpgrade, brewSetPinned, appVersion, catalogReverseDependents } from "$lib/api";
   import { isLinux } from "$lib/util/platform";
   import { safeOpenUrl } from "$lib/util/url";
   import { bareToken } from "$lib/util/token";
@@ -293,6 +295,29 @@
       }
     } catch (e) {
       reportableToastError("Upgrade failed", e);
+    }
+  }
+
+  let pinBusy = $state(false);
+
+  /** Issue #90 — pin/unpin the current package via `brew pin`/`unpin`. Pinning
+   *  holds it back from `brew upgrade` (including greedy), so it drops out of
+   *  the update count. Non-streaming: resolves once brew flips the flag, then
+   *  reloads the list + detail so the pinned state and counts re-derive. */
+  async function doTogglePinned() {
+    if (!ui.selectedPackage || pinBusy) return;
+    const { name, kind } = ui.selectedPackage;
+    const nextPinned = !(pkg?.pinned ?? false);
+    pinBusy = true;
+    try {
+      await brewSetPinned(name, kind, nextPinned);
+      toast.success(nextPinned ? `Pinned ${name}` : `Unpinned ${name}`);
+      await packages.load(true);
+      if (ui.selectedPackage) loadDetail(ui.selectedPackage.name, ui.selectedPackage.kind);
+    } catch (e) {
+      reportableToastError(nextPinned ? "Pin failed" : "Unpin failed", e);
+    } finally {
+      pinBusy = false;
     }
   }
 
@@ -1729,6 +1754,21 @@
     </div>
 
     <footer class="actions">
+      {#if isInstalled}
+        <Button
+          variant="secondary"
+          onclick={doTogglePinned}
+          loading={pinBusy}
+          title={pkg?.pinned
+            ? "Unpin — let brew upgrade update this again"
+            : ui.selectedPackage?.kind === "cask"
+              ? "Pin — hold back from brew upgrade. A cask that self-updates may still update on its own."
+              : "Pin — hold back from brew upgrade"}
+        >
+          {#snippet icon()}{#if pkg?.pinned}<PinOff size={16} />{:else}<Pin size={16} />{/if}{/snippet}
+          {pkg?.pinned ? "Unpin" : "Pin"}
+        </Button>
+      {/if}
       {#if isInstalled && isOutdated}
         <Button variant="primary" onclick={doUpgrade}>
           {#snippet icon()}<ArrowUpCircle size={16} />{/snippet}

--- a/src/lib/components/PackageRow.svelte
+++ b/src/lib/components/PackageRow.svelte
@@ -150,6 +150,12 @@
            card. -->
       <span class="vuln-dot vuln-tone-{vulnTone}" title={vulnTitle} aria-label={vulnTitle}></span>
     {/if}
+    {#if pkg.pinned}
+      <!-- Pinned badge (#90) — package is held back from brew upgrade. -->
+      <span title="Pinned — held back from brew upgrade">
+        <Pill tone="neutral">Pinned</Pill>
+      </span>
+    {/if}
   </span>
   <span class="outdated">
     {#if pkg.outdated}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -117,7 +117,9 @@
 
   function badge(id: SidebarSection): string | null {
     if (id === "library") {
-      const o = packages.outdated.length;
+      // Nag badge counts only *upgradable* updates — pinned packages are
+      // intentionally held back (#90), so they don't contribute to the count.
+      const o = packages.outdatedUpgradable.length;
       return o > 0 ? String(o) : null;
     }
     if (id === "snapshots") {

--- a/src/lib/stores/library.svelte.ts
+++ b/src/lib/stores/library.svelte.ts
@@ -13,6 +13,9 @@ export type LibraryFilter =
   | "formulae"
   | "casks"
   | "outdated"
+  /** #90 — show only pinned packages (held back from `brew upgrade`).
+      Keys on `Package.pinned` (formulae + casks). Always available. */
+  | "pinned"
   /** Feature #3 — installed-on-request ("Manual") vs installed-as-a-
       dependency-only ("Dependency"). Both key on the per-keg brew flags
       carried on `Package` (`installedOnRequest` / `installedAsDependency`).

--- a/src/lib/stores/packages.svelte.ts
+++ b/src/lib/stores/packages.svelte.ts
@@ -18,6 +18,15 @@ class PackagesStore {
 
   outdated = $derived(this.all.filter((p) => p.outdated));
 
+  /**
+   * Outdated packages that aren't pinned — the honest "updates available" set
+   * (#90/#134). A pinned package may have a newer version, but the user has
+   * deliberately held it back and `brew upgrade` skips it, so it must not
+   * inflate the nag count or the "Upgrade all" set. Lists that want to *show*
+   * pinned-but-outdated rows (with a pin badge) still use `outdated`.
+   */
+  outdatedUpgradable = $derived(this.outdated.filter((p) => !p.pinned));
+
   async load(force = false) {
     if (this.loading) return;
     if (!force && this.list && this.lastLoadedAt && Date.now() - this.lastLoadedAt < 5_000) {


### PR DESCRIPTION
Lets users **pin/unpin packages** so "Update all" leaves them alone — the recurring "stop nagging me about Chrome" request. Both shells; `brew pin` covers formulae **and** casks (the actual reported targets are casks).

**Pin/Unpin action** — pure arg-builder + `brew_set_pinned` (Tauri) / `BrewArgs.setPinned` + `AppModel.setPinnedDetail` (native). Non-streaming, write-locked, cache-invalidating.
**Honest counts** — pinned packages drop out of the sidebar badge / Dashboard "updates available" / "Upgrade all (N)"; the Outdated filter still lists them, badged.
**Library refresh** — new **Pinned** filter tab, per-tab counts removed, and a bottom status bar (Services-header style) that leads with the active tab's count. Native cask-pin parse fix; `pinnedCount` now counts casks.

Verified end-to-end against live brew (pin surfaces for formula + cask; pinned+outdated excluded from the upgradable count). cargo 669 · swift 174 · svelte-check 0 · vitest 42.

Closes #90. Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9iMFjHE21ePTjcbHpTXt6
