### PR TITLE
fix: install-trend sparkline stops mixing metric scales (cliff artifact)

### DIFF
--- a/native/Sources/BrewBrowserKit/PackageDetailView.swift
+++ b/native/Sources/BrewBrowserKit/PackageDetailView.swift
@@ -522,11 +522,14 @@ struct PackageDetailView: View {
     }
 
     private func sparkValues(_ s: TrendingHistorySeries) -> [Double] {
-        s.points.compactMap { p in
-            if let e = p.estimatedDailyInstalls { return Double(e) }
-            if let c = p.count30d { return Double(c) }
-            return nil
-        }
+        // Plot ONLY the per-day estimate — a single, consistent scale. The
+        // early "seed"/bootstrap points carry a cumulative `count30d` (hundreds
+        // of thousands to millions) but no `estimatedDailyInstalls`; falling
+        // back to `count30d` mixed a ~100–1000× larger value into a daily
+        // series, so the auto-scaled y-axis pinned that first point to the top
+        // and flattened the real trend into a baseline (the cliff-then-flat
+        // artifact every package showed). Seed points simply drop out.
+        s.points.compactMap { $0.estimatedDailyInstalls.map(Double.init) }
     }
 
     private func useCasesCard(_ cases: [String]) -> some View {

--- a/src/lib/components/PackageDetail.svelte
+++ b/src/lib/components/PackageDetail.svelte
@@ -1405,20 +1405,25 @@
              when off — the section simply doesn't exist. -->
         {#if trendingHistory.enabled}
           {@const series = trendingHistory.seriesFor(pkg.name, pkg.kind)}
-          {#if series && series.points.length >= 2}
+          <!-- Plot ONLY points that carry a per-day estimate — a single,
+               consistent scale. The early "seed"/bootstrap points hold a
+               cumulative count30d (hundreds of thousands to millions) but no
+               estimatedDailyInstalls; falling back to count30d mixed a
+               ~100–1000× larger value into a daily series, so the chart pinned
+               that first point to the top and flattened the real trend into a
+               baseline (the cliff-then-flat artifact every package showed).
+               Seed points simply drop out. -->
+          {@const daily = (series?.points ?? []).filter(
+            (p) => p.estimatedDailyInstalls != null,
+          )}
+          {#if daily.length >= 2}
             <section class="trend-card" aria-label={`Install trend for ${pkg.name}`}>
               <header class="trend-head">
                 <h3>Install trend</h3>
-                <span class="trend-meta text-muted">
-                  {#if series.points.some((p) => p.source === "seed")}
-                    Bootstrap + daily snapshots — granularity grows over time
-                  {:else}
-                    Daily install snapshots
-                  {/if}
-                </span>
+                <span class="trend-meta text-muted">Daily install snapshots</span>
               </header>
               <TrendingSparkline
-                data={series.points.map((p) => p.estimatedDailyInstalls ?? p.count30d ?? 0)}
+                data={daily.map((p) => p.estimatedDailyInstalls ?? 0)}
                 variant="detail"
                 title={`${pkg.name} install trend`}
               />


### PR DESCRIPTION
Every package's **Install trend** sparkline showed the same cliff-then-flat shape. The chart fell back to `count30d` (a cumulative 30-day total, 100k–2M) when a point lacked `estimatedDailyInstalls` (per-day, tens–thousands) — the early "seed" points. Mixing the two scales pinned the first point to the top of the auto-scaled axis and flattened the real trend.

Plot only points with `estimatedDailyInstalls` (single consistent scale); seed points drop out. Both shells. Verified on live data: dominating first value 323,888→115 (wget), 1.2M→10k (git), 2.1M→12k (node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9iMFjHE21ePTjcbHpTXt6
