### PR TITLE
fix(native): Outdated filter drops tap-installed packages (tap-name mismatch)

### DIFF
--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -172,8 +172,14 @@ public final class AppModel {
         KeyPathComparator(\LibraryRow.name, order: .forward)
     ]
 
-    /// Set of outdated package names for O(1) per-row tagging.
-    private var outdatedNames: Set<String> { Set(outdated.map(\.name)) }
+    /// Set of outdated package names for O(1) per-row tagging, keyed by BARE
+    /// token. `brew outdated` reports tap formulae fully-qualified
+    /// (`shivammathur/php/php@8.4`) while `brew info --installed` — the source
+    /// of the Library rows — reports the bare token (`php@8.4`). Matching the
+    /// raw names dropped tap-installed packages from the Outdated filter and
+    /// their outdated dot; normalising both sides through `bareToken` fixes it
+    /// (same tap-name class as #92). Compare with `bareToken(pkg.name)`.
+    private var outdatedNames: Set<String> { Set(outdated.map { Self.bareToken($0.name) }) }
 
     /// The Library rows after the type filter + text query, before sorting.
     /// Each row carries its outdated flag and (AI-gated) enrichment summary so
@@ -193,7 +199,7 @@ public final class AppModel {
             case .all:        break
             case .formulae:   guard pkg.kind == .formula else { return nil }
             case .casks:      guard pkg.kind == .cask else { return nil }
-            case .outdated:   guard outdatedSet.contains(pkg.name) else { return nil }
+            case .outdated:   guard outdatedSet.contains(Self.bareToken(pkg.name)) else { return nil }
             // Manual = installed on request; Dependency = a formula NOT on request
             // (casks are always on-request, so never appear under Dependency) (#3).
             case .manual:     guard pkg.installedOnRequest else { return nil }
@@ -212,7 +218,7 @@ public final class AppModel {
                 friendlyName: (friendly != pkg.name) ? friendly : "",
                 version: pkg.version,
                 kind: pkg.kind,
-                isOutdated: outdatedSet.contains(pkg.name),
+                isOutdated: outdatedSet.contains(Self.bareToken(pkg.name)),
                 summary: showSummary ? (entry?.summary ?? "") : "",
                 maxSeverity: (vuln?.total ?? 0) > 0 ? vuln?.maxSeverity : nil,
                 vulnCount: vuln?.total ?? 0,

--- a/native/Tests/BrewBrowserKitTests/ManualDependencyFilterTests.swift
+++ b/native/Tests/BrewBrowserKitTests/ManualDependencyFilterTests.swift
@@ -177,6 +177,30 @@ struct ManualDependencyFilterTests {
         #expect(names == ["openssl@3", "legacy-keg"])
     }
 
+    @Test func outdatedFilterMatchesTapQualifiedOutdatedName() {
+        // Regression: `brew outdated` reports tap formulae fully-qualified
+        // (`shivammathur/php/php@8.4`) while `brew info --installed` — the Library
+        // row source — reports the bare token (`php@8.4`). The outdated filter
+        // must match through bareToken, else tap-installed packages get dropped
+        // from the filter + outdated dot (the "Swift shows 8, Tauri shows 9" bug).
+        let m = AppModel()
+        m.installed = [
+            InstalledPackage(name: "php@8.4", version: "8.4.20", kind: .formula, installedOnRequest: true),
+            InstalledPackage(name: "wget", version: "1.24", kind: .formula, installedOnRequest: true),
+        ]
+        m.outdated = [
+            OutdatedPackage(name: "shivammathur/php/php@8.4", installedVersion: "8.4.20",
+                            currentVersion: "8.4.23", kind: .formula),
+        ]
+        m.libraryFilter = .outdated
+        #expect(m.libraryRows.contains { $0.name == "php@8.4" })  // tap-qualified matched the bare token
+        #expect(m.libraryFilterCount(.outdated) == 1)
+        // A bare outdated name still matches (no regression for non-tap formulae).
+        m.outdated = [OutdatedPackage(name: "wget", installedVersion: "1.24",
+                                      currentVersion: "1.25", kind: .formula)]
+        #expect(m.libraryRows.map(\.name) == ["wget"])
+    }
+
     @Test func bothTruePackageShowsManualNotDependency() {
         // `ruby` is on request AND a dependency of another formula → Manual wins,
         // never appears under Dependency (predicate excludes on-request).


### PR DESCRIPTION
Native's Outdated count read **one short of Tauri's** (8 vs 9) whenever a **tap-installed** formula was outdated. `brew outdated` reports tap formulae fully-qualified (`shivammathur/php/php@8.4`) while `brew info --installed` — the Library row source — reports the bare token (`php@8.4`). Native matched the raw name sets, so tap-installed outdated packages were silently dropped from the Outdated filter and their outdated dot.

Normalize both sides through `bareToken` (the same last-segment rule the #92 install matching uses). Regression test covers the tap-qualified match + bare-name non-regression. Native-only. swift 174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9iMFjHE21ePTjcbHpTXt6
