### PR TITLE
fix: native Keychain-prompt parity + Linuxbrew PATH (follow-up to #152)

### DIFF
--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -1766,6 +1766,7 @@ public final class AppModel {
             let status = try await githubService.pollDeviceFlow(deviceCode: flow.deviceCode, interval: flow.interval)
             deviceFlow = nil
             githubStatus = status
+            persistGithubSignedInHint(status)
             // Now signed in — light up the dashboard card + toolbar chip.
             if status.signedIn { await loadGithubStats() }
             return status.signedIn
@@ -2144,8 +2145,20 @@ public final class AppModel {
     /// Eagerly read GitHub sign-in status (Keychain) at launch so the toolbar's
     /// Octocat chip can render. Signed-out users have no token → no Keychain ACL
     /// prompt; only previously-signed-in users see the one-time prompt.
+    /// Persisted hint that the user has completed GitHub sign-in on this machine.
+    /// Mirrors the Tauri `brew-browser:github:signed-in` localStorage flag (#152,
+    /// @fallenmaverick): it gates the eager startup Keychain read (ContentView's
+    /// `.task`) so a user who never touches GitHub sees no macOS Keychain prompt
+    /// on launch. Set true on any signed-in status read, cleared when signed out.
+    private static let githubSignedInKey = "brew-browser:github:signed-in"
+    var githubSignedInHint: Bool { UserDefaults.standard.bool(forKey: Self.githubSignedInKey) }
+    private func persistGithubSignedInHint(_ status: GithubStatus?) {
+        UserDefaults.standard.set(status?.signedIn ?? false, forKey: Self.githubSignedInKey)
+    }
+
     func loadGithubStatus() async {
         githubStatus = githubService.status()
+        persistGithubSignedInHint(githubStatus)
         if !(githubStatus?.signedIn ?? false) {
             // Signed out (or not yet) — reset card state so a later sign-in
             // reloads fresh (the idempotent loadGithubStats keys off this).

--- a/native/Sources/BrewBrowserKit/ContentView.swift
+++ b/native/Sources/BrewBrowserKit/ContentView.swift
@@ -152,8 +152,12 @@ public struct ContentView: View {
             // Parse the bundled categories/enrichment JSON in the background at
             // launch so the heavy decode never blocks first paint.
             .task { await model.loadBundledData() }
-            // Eagerly read GitHub status so the toolbar Octocat chip can render.
-            .task { await model.loadGithubStatus() }
+            // Read GitHub status so the toolbar Octocat chip can render — but only
+            // for users who've signed in before (persisted hint), so a user who
+            // never touches GitHub gets no macOS Keychain prompt on launch. Parity
+            // with the Tauri localStorage gate (#152). Sign-in sets the hint, so the
+            // first post-sign-in launch (and every one after) reads status here.
+            .task { if model.githubSignedInHint { await model.loadGithubStatus() } }
             // Creds are lazy — re-read status when the window becomes active
             // again (e.g. after signing in via Settings) so the chip + dashboard
             // card light up without a manual refresh.

--- a/src-tauri/src/brew/exec.rs
+++ b/src-tauri/src/brew/exec.rs
@@ -74,8 +74,11 @@ pub(crate) fn apply_brew_env(cmd: &mut Command) {
 
     // Ensure Homebrew paths are prepended to PATH so GUI process launches (Finder, Dock)
     // inherit correct Homebrew resolution priority for subcommands (git, openssl, python).
+    // macOS Apple Silicon (/opt/homebrew) + Intel (/usr/local) + Linuxbrew
+    // (/home/linuxbrew/.linuxbrew). Non-existent prefixes on a given host are
+    // harmless — they just don't resolve anything.
     let path = std::env::var_os("PATH").unwrap_or_default();
-    let additional_paths = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin";
+    let additional_paths = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin";
     let mut new_path = std::ffi::OsString::from(additional_paths);
     if !path.is_empty() {
         new_path.push(":");


### PR DESCRIPTION
Follow-up to **#152** (@fallenmaverick) — closes the two parity/coverage gaps that PR left open, keeping both shells and all three platforms consistent.

### 1. Native Keychain-prompt parity
#152 gated the **Tauri** app's eager startup GitHub-status read behind a `localStorage` `brew-browser:github:signed-in` flag, so users who never touch GitHub get no macOS Keychain prompt on launch. The **native** app had the identical eager read (`ContentView.swift` → `.task { await model.loadGithubStatus() }`). This adds a `UserDefaults` hint of the same name — set on any signed-in status read and on device-flow sign-in — and gates the startup task on it. Mirrors the Tauri behavior exactly: sign-in sets the hint, so the first post-sign-in launch (and every one after) reads status; a never-signed-in user's launch never touches the Keychain.

### 2. Linuxbrew PATH
#152's PATH prepend in `brew/exec.rs` covered macOS `/opt/homebrew` (Apple Silicon) + `/usr/local` (Intel) but not **Linuxbrew**. Adds `/home/linuxbrew/.linuxbrew/{bin,sbin}` so GUI-launched Linux builds resolve brew subcommands (git, openssl, …). Non-existent prefixes on a given host are harmless.

### Testing
- native `swift build` + **199 tests** pass
- Rust build clean

Thanks @fallenmaverick — this rides on top of your #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9iMFjHE21ePTjcbHpTXt6