### PR TITLE
Release prep: 0.7.2 / native 0.3.2 (Homebrew 6.0+ vuln fix + Keychain/PATH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,16 @@ Contributions welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the dev loop
 
 ## Status
 
-**Next release:** Tauri `0.7.1` and native `0.3.1` (split-track; native 0.3.1 ≙ Tauri 0.7.1, single tag `v0.7.1`) — a small follow-up that adds the **resizable Activity console** (community contribution by @cseelye) which landed just after the 0.7.0 build, plus a Linux-CI fix so the `.deb` / `.rpm` / `.AppImage` bundles publish again. Full notes: [docs/release-notes/0.7.1.md](./docs/release-notes/0.7.1.md).
+**Next release:** Tauri `0.7.2` and native `0.3.2` (split-track; native 0.3.2 ≙ Tauri 0.7.2, single tag `v0.7.2`) — a bug-fix patch led by **Homebrew 6.0+ compatibility** for vulnerability scanning (the `vulns` subcommand moved into core; detection + the install affordance now handle it instead of chasing a deleted formula), plus **no more startup macOS Keychain prompts** (both shells) and a WebKit fresh-scan-time parsing fix. Community fix by @fallenmaverick. Full notes: [docs/release-notes/0.7.2.md](./docs/release-notes/0.7.2.md).
 
-**Current stable release:** Tauri `0.7.0` + native `0.3.0` shipped signed + notarized together — headlined by **Bundles** (capability-gated one-click package stacks, 9 recipes, both shells), plus per-package **pin / unpin** (formulae and casks), in-app brew command options with reactive recovery, **Brew Doctor + Cleanup** on the Dashboard Storage card, and vulnerability-scanning hardening. All seven core panes plus Bundles live in both shells; optional GitHub integration via OAuth Device Flow is intent-discovered; opt-in **Enhanced Trending History** (v0.4.0+) and **Vulnerability Scanning** (v0.5.0+) sit beyond the always-on core; Settings ships with Offline Mode and a corrupt-recovery default.
+**Current stable release:** Tauri `0.7.1` + native `0.3.1` shipped signed + notarized together — a small follow-up to the Bundles release adding the **resizable Activity console** (community contribution by @cseelye) and a Linux-CI fix so the `.deb` / `.rpm` / `.AppImage` bundles publish. The prior `0.7.0` was the **Bundles** headline release (capability-gated one-click package stacks, 9 recipes, both shells) plus pin/unpin, in-app brew command options, Brew Doctor + Cleanup, and vulnerability-scanning hardening. Optional GitHub integration via OAuth Device Flow is intent-discovered; opt-in **Enhanced Trending History** (v0.4.0+) and **Vulnerability Scanning** (v0.5.0+) sit beyond the always-on core; Settings ships with Offline Mode and a corrupt-recovery default.
+
+**v0.7.2 / native 0.3.2** — bug-fix patch. Highlights:
+- **Homebrew 6.0+ vuln-scan compatibility** (#152, @fallenmaverick). `vulns` moved into core in brew 6.0+ and the standalone tap was deleted; detection now falls back to `brew help vulns` and the install affordance runs `brew update` instead of chasing a deleted formula. Both shells.
+- **No startup Keychain prompts.** The eager GitHub-status read on launch is gated behind a persisted "signed-in before" flag, so users who never use GitHub get no macOS Keychain prompt (Tauri #152, native #155).
+- **"59 minutes ago" scan-time fix** — WebKit nanosecond ISO timestamps are truncated to ms before parsing (#152).
+- **Homebrew subprocess env** — native `VulnsService` inherits the app's brew environment; the Tauri PATH prepend now includes Linuxbrew (#152, #155).
+- Full notes: [docs/release-notes/0.7.2.md](./docs/release-notes/0.7.2.md).
 
 **v0.7.1 / native 0.3.1** — small follow-up. Highlights:
 - **Resizable Activity console** (#136) — the live `brew` output drawer resizes in both shells, with the height persisted across launches. Community contribution by **@cseelye**. (Listed in the 0.7.0 notes but it landed just after that build; it ships here.)

--- a/docs/release-notes/0.7.2.md
+++ b/docs/release-notes/0.7.2.md
@@ -1,0 +1,55 @@
+# brew-browser 0.7.2 / Brew Browser native 0.3.2
+
+A bug-fix patch. Signed + notarized; Tauri is the macOS 13+ / Linux build,
+native is the macOS 26 SwiftUI build. Split-track versions track the same batch
+(native 0.3.2 ≙ Tauri 0.7.2).
+
+## Fixes
+
+### Homebrew 6.0+ compatibility for vulnerability scanning
+The headline fix. In Homebrew 6.0+, the `vulns` subcommand moved into core and
+the standalone `homebrew/brew-vulns` tap/formula was deprecated and deleted. As
+a result, on current Homebrew the vulnerability-scan feature was effectively
+broken: detection failed and the "Install brew-vulns" button chased a
+formula that no longer exists. Now:
+
+- Detection falls back to `brew help vulns` (the built-in subcommand) when the
+  legacy prefix check fails — both shells.
+- The install/remediation command is `brew update` (which is how you get the
+  now-built-in subcommand) instead of installing a deleted formula.
+- Formula-name validation accepts 2-segment tap-qualified names (`user/name`)
+  in addition to `user/repo/name`, while still rejecting shell metacharacters
+  and path traversal.
+
+Thanks to **@fallenmaverick** (#152).
+
+### No more startup macOS Keychain prompts
+The app read GitHub credential status eagerly on launch, which could trigger a
+macOS Keychain access prompt for users who'd never signed in. Both shells now
+gate that startup read behind a persisted "has signed in before" flag
+(`localStorage` on Tauri via #152, `UserDefaults` on native via #155), so a user
+who never touches GitHub sees no Keychain prompt on launch.
+
+### "59 minutes ago" scan time (WebKit)
+Under WebKit, parsing the backend's nanosecond-precision ISO timestamps could
+mis-parse the timezone and show a fresh scan as "59 minutes ago" / "1 hour ago".
+Timestamps are now truncated to millisecond precision before parsing (#152).
+
+### Homebrew subprocess environment
+- Native `VulnsService` subprocesses now inherit the same Homebrew environment
+  (`$HOME`, analytics-off flags) as the rest of the app, so `brew` runs
+  correctly under the launchd GUI-app context (#152).
+- The Tauri backend prepends Homebrew bin paths to `PATH` for spawned commands,
+  now including Linuxbrew (`/home/linuxbrew/.linuxbrew/{bin,sbin}`) alongside
+  macOS `/opt/homebrew` + `/usr/local` (#152, #155).
+
+## Acknowledgments
+
+- **@fallenmaverick** — the Homebrew 6.0+ vuln compatibility, startup Keychain
+  prompt, WebKit date-parsing, and Swift subprocess-env fixes (#152).
+
+## Issues & feedback
+
+[github.com/msitarzewski/brew-browser/issues](https://github.com/msitarzewski/brew-browser/issues).
+Every error toast in the app has a "Report" button that pre-fills the issue with
+your context.

--- a/landing/index.html
+++ b/landing/index.html
@@ -69,7 +69,7 @@
     "operatingSystem": "macOS 13+",
     "url": "https://brew-browser.zerologic.com/",
     "downloadUrl": "https://github.com/msitarzewski/brew-browser/releases/latest",
-    "softwareVersion": "0.7.1",
+    "softwareVersion": "0.7.2",
     "license": "https://opensource.org/licenses/MIT",
     "author": {
       "@type": "Person",

--- a/memory-bank/releases/0.7.0/README.md
+++ b/memory-bank/releases/0.7.0/README.md
@@ -1,6 +1,6 @@
 # Release 0.7.0 / native 0.3.0
 
-**Status:** 🚧 In progress — contents on `main` (unreleased), headline feature (Bundles) in planning.
+**Status:** ✅ SHIPPED 2026-07-15 — `v0.7.0` (Tauri 0.7.0 / native 0.3.0), signed + notarized, both shells, tap cask + feeds live. A same-day follow-up **`v0.7.1` / native 0.3.1** shipped right after (see "0.7.1 follow-up" below).
 **Baseline:** 0.6.0 / native 0.2.0 (tag `v0.6.0`).
 **Version step:** minor — new user-facing feature (pin/unpin; Bundles to follow). Split-track per [decisions.md](../../decisions.md): Tauri/web (+Linux) `0.6.0 → 0.7.0`, native macOS `0.2.0 → 0.3.0`. Same feature set under two numbers; release notes state the equivalence ("native 0.3.0 ≙ Tauri 0.7.0"). Single git tag `v0.7.0`.
 
@@ -65,15 +65,21 @@ Curated **one-click package stacks** with post-install setup guidance, **capabil
 - [x] Decide: **Bundles rides THIS release** (0.7.0/0.3.0), plan complete → `bundles/`. ✅ 2026-07-12.
 - [x] Build Bundles **M1–M5, both shells** (branch `feat/bundles`, 2026-07-13): capability engine, recipe contract + validator, browse/install UI, setup guidance, CI + CONTRIBUTING, **and the M5 live-refresh client**. Both apps launch clean with the Bundles section; no unresolved TODOs in new code.
 - [x] **Post-M5 refinement (2026-07-13):** list+Details-pane refactor, recipe set 6→9 (Agentic Web Dev + LAMP + LEMP; expanded Image Gen/Media/Web Dev/Databases), `description` intent field (incl. Rust-struct round-trip fix), readiness dedup, clickable inline package descriptions, per-package Install. Gate: recipes 9/9 · native swift build + 195 tests · Rust bundle tests 9/9 · Tauri svelte-check 0 / vitest 57. See the Bundles section above.
-- [ ] **Serve the live-refresh endpoint**: publish `bundles.json` to `<host>/bundles/bundles.json` (release-publish step, gated to the user). The M5 client is built + unit-tested and ships safely (bundled copy kept on any error / 404); a live 200 activates the refresh. Until then it's a no-op fail-soft — nothing to verify app-side.
-- [ ] Version bumps: `package.json` / `Cargo.toml` / `tauri.conf.json` → `0.7.0`; native `build-app.sh` CFBundleShortVersionString → `0.3.0`. Docs (README, BUILD.md, release-notes/unreleased.md, native/README) consistent.
-- [ ] Live-verify on main: pin/unpin (formula + cask), Library bottom bar + Pinned tab, list-scale, install-trend, vulnerable-footer nav, GHSA enrichment.
-- [ ] Build + notarize both shells (Tauri arm64 + x64 dmgs + updater `.app.tar.gz`; native arm64 + x64 dmgs). Recipe: [build-deployment / RELEASE-BUILD GOTCHAS in project-resume-state].
-- [ ] `gh release create v0.7.0` with assets + release notes.
-- [ ] rsync feeds to host: Tauri `updater.json` (both arches) + native Sparkle `appcast.xml` (arm64-only feed).
-- [ ] **Tap cask bump** (separate repo `msitarzewski/homebrew-brew-browser`): version + per-arch sha256 (doesn't auto-follow releases).
-- [ ] Close issues fixed-in-build: **#90**, **#134** (pin); **#62**, **#92** (already fixed via #103, still open — close with "fixed in 0.7.0").
-- [ ] Update `progress.md` + `tasks/2026-07/README.md`.
+- [x] **Serve the live-refresh endpoint**: `bundles.json` served at `<host>/bundles/bundles.json` (endpoint live, schemaVersion 1). ✅ 2026-07-15.
+- [x] Version bumps → `0.7.0` / native `0.3.0` (then `0.7.1` / `0.3.1` for the follow-up). Docs consistent. ✅
+- [x] Live-verify on main (user screenshots): Bundles list+detail, readiness, per-package install, pin/unpin, etc. ✅
+- [x] Build + notarize both shells — Tauri arm64+x64 dmgs + updater `.app.tar.gz`; native arm64+x64 dmgs + Sparkle appcast. All 4 dmgs Gatekeeper-accepted. ✅ 2026-07-15.
+- [x] `gh release create v0.7.0` (6 assets + notes). ✅ [releases/tag/v0.7.0](https://github.com/msitarzewski/brew-browser/releases/tag/v0.7.0).
+- [x] rsync feeds to host: `updater.json` (both arches) + Sparkle `appcast.xml`. ✅
+- [x] **Tap cask bump** (`msitarzewski/homebrew-brew-browser`): bumped to **0.7.1** (it was stuck at 0.6.0; the 0.7.0 bump was folded into the 0.7.1 publish). ✅
+- [x] Close issues **#90 / #134 / #62 / #92** — all closed. ✅
+
+## 0.7.1 follow-up (SHIPPED 2026-07-15, tag `v0.7.1` / native 0.3.1)
+Same-day patch release. **Notes: [../0.7.1 → docs/release-notes/0.7.1.md](../../../docs/release-notes/0.7.1.md).**
+- **Resizable Activity console** (#136, community @cseelye) — merged to main *after* the 0.7.0 build was cut, so it shipped here. Both shells; drawer height persists.
+- **Linux CI fix** (#149) — the Linux workflow was failing at updater-artifact signing (no `TAURI_SIGNING_PRIVATE_KEY` on CI) *after* building `.deb`/`.rpm`/`.AppImage`, so no Linux artifacts on any tagged release (v0.6.0/v0.7.0 both red). Fix: `--config '{"bundle":{"createUpdaterArtifacts":false}}'` for the Linux build only (Linux auto-updater is unwired). v0.7.1 tag CI is the first green Linux run.
+- **⚠️ LESSON:** I listed the resizable console in the 0.7.0 notes as *shipped* when it had only been *reconciled + test-merged* (a throwaway branch, green 199 tests) — never actually merged to main / never in the 0.7.0 build. **Don't mark a PR "shipped" until it's on main AND in the built artifact.** 0.7.1 corrected the 0.7.0 notes (de-listed it) and shipped it for real. Same trap as treating "mergeable/ready" as "merged".
+- Gate: Tauri svelte-check 0 / vitest 57 · native swift build + 199 tests · all 4 dmgs notarized. Published via one `!`-run script (release + feeds + tap bump), gh operations gated to the user (auto-mode classifier blocks agent-run `gh release create` / rsync / community-PR merge — see [[project-resume-state]] permission notes).
 
 ## Open threads / housekeeping
 - **Stale local branches**: many old `release/*`, `docs/*`, merged `feat/*` branches linger locally (not on `main`). Prune candidate — confirm with user first.

--- a/native/build-app.sh
+++ b/native/build-app.sh
@@ -110,8 +110,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
     <key>CFBundleIdentifier</key><string>com.zerologic.brew-browser-native</string>
     <key>CFBundleExecutable</key><string>BrewBrowser</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.3.1</string>
-    <key>CFBundleVersion</key><string>4</string>
+    <key>CFBundleShortVersionString</key><string>0.3.2</string>
+    <key>CFBundleVersion</key><string>5</string>
     <key>CFBundleIconFile</key><string>AppIcon</string>
     <key>CFBundleIconName</key><string>AppIcon</string>
     <key>LSMinimumSystemVersion</key><string>26.0</string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brew-browser",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "An honestly open Homebrew browser, manager, and Brewfile snapshot tool.",
   "type": "module",
   "author": "Michael Sitarzewski",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "brew-browser"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brew-browser"
-version = "0.7.1"
+version = "0.7.2"
 description = "An honestly open Homebrew browser, manager, and Brewfile snapshot tool."
 authors = ["Michael Sitarzewski"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "brew-browser",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.zerologic.brew-browser",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bug-fix patch. Ships **#152** (@fallenmaverick — Homebrew 6.0+ vuln-scan compatibility, startup Keychain prompts, WebKit date parsing, Swift subprocess env) and **#155** (native Keychain-prompt parity, Linuxbrew PATH) to users. Both are on main but unshipped; the brew-6 breakage means the vuln-scan feature is dead for current-Homebrew users until this ships.

Versions → Tauri 0.7.2 / native 0.3.2. New `docs/release-notes/0.7.2.md`; also folds in the pending 0.7.0/0.7.1 "SHIPPED" release-tracker mark.

Gate: Tauri svelte-check 0 / vitest 57 · native swift build + 199 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9iMFjHE21ePTjcbHpTXt6