### PR TITLE
fix(rosetta2): detect Rosetta 2, route brew through arch -arm64, add notice card

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,44 @@
 # Active Context
 
+> ## 🔧 IN FLIGHT 2026-08-10: `fix/rosetta2-arch-detection` (committed + pushed, PR pending)
+>
+> **Issue #158** — a user installed the **Intel (x64) dmg on Apple Silicon**, so
+> the app runs under Rosetta 2; every spawned `brew` (arm `/opt/homebrew`) fails
+> *"Cannot install under Rosetta 2 in ARM default prefix."* Terminal works
+> because that `brew` runs natively. Apple retires Rosetta 2 in a future macOS
+> release, so the native build is the durable fix.
+>
+> **Fix (both shells), committed `1d5e461`, pushed, all green (Rust 688 · native
+> 201 · svelte-check 0 · vitest 57):**
+>
+> - **Detect** via `sysctl.proc_translated` — a *runtime* check (the compile-time
+>   `#if arch(arm64)` / `cfg!(target_arch)` can't see translation). Cached; a
+>   pure helper is unit-tested. `SystemProfile.is_translated()` (Rust) /
+>   `SystemProfile.isTranslated()` (Swift). A `BREWBROWSER_FAKE_ROSETTA=1`
+>   override (mirrors `BREWBROWSER_FAKE_RAM_GB`) exercises the path on native-arm.
+> - **Bridge**: every brew spawn routes through `arch -arm64 <brew>` when
+>   translated **and** the prefix is `/opt/homebrew` (Intel brew at `/usr/local`
+>   is left alone), so operations keep working. One helper per shell —
+>   `exec.rs brew_command()` / `BrewService.brewInvocation()` — which also closed
+>   a gap where `brew bundle check` skipped the analytics-off env.
+> - **Notice**: a Dashboard **card** (NOT a top-of-window banner), same
+>   `.card`/`GroupBox` + warning-row language as the Exposure card, steering to
+>   the Apple Silicon build. `RosettaCard` in `DashboardView.swift`; a `.card` in
+>   `Dashboard.svelte`. `SystemStatus.rosettaTranslated` carries the flag to the
+>   Tauri frontend at startup.
+>
+> **Lesson (SwiftUI window sizing):** the first attempt was a top banner wrapping
+> `NavigationSplitView` in a `VStack`; that broke free window resizing under the
+> scene's `.windowResizability(.contentMinSize)`. The true culprit was
+> `.fixedSize(vertical: true)` on the banner text — it locked the window's
+> minimum height — compounded by a corrupted frame persisted under the
+> `NSWindow Frame SwiftUI.WindowGroup<…>` defaults key. Resolved by moving to a
+> Dashboard card (window chrome untouched). Full record to land in a task doc.
+>
+> **Next:** open PR (closes #158) → cut release **Tauri 0.7.3 / native 0.3.3** →
+> reply on #158 → issue-triage sweep (brew-not-app class + #128/#139/#159/#160,
+> label #161 `enhancement`).
+
 > ## 🔧 IN FLIGHT 2026-06-10/11: `feat/intel-builds-and-onboarding` (committed + pushed, PR pending)
 >
 > Triggered by post-release "corrupt download" reports → root cause was Intel

--- a/native/Sources/BrewBrowserKit/AppModel.swift
+++ b/native/Sources/BrewBrowserKit/AppModel.swift
@@ -844,6 +844,14 @@ public final class AppModel {
     /// can force Marginal/Blocked states on a high-RAM dev Mac.
     var systemProfile = SystemProfile.detect()
 
+    /// True when the app itself is running under Rosetta 2 — an Intel build on
+    /// an Apple Silicon Mac. Drives `RosettaBanner`, which steers the user to
+    /// the native Apple Silicon build (brew can't install into the arm
+    /// `/opt/homebrew` prefix from a translated process without the
+    /// `arch -arm64` stopgap). Read once at construction — translation state is
+    /// fixed for the process lifetime. See issue #158.
+    let rosettaTranslated = SystemProfile.isTranslated()
+
     /// Capability verdict for a bundle on this host (M3). Pure — just routes the
     /// bundle's `requires`/`capabilityNotes` and the cached profile through the
     /// M1 readiness function.

--- a/native/Sources/BrewBrowserKit/BrewService.swift
+++ b/native/Sources/BrewBrowserKit/BrewService.swift
@@ -223,12 +223,29 @@ struct BrewService: Sendable {
         return env
     }
 
+    /// Build the (executable, arguments) pair for a `brew` spawn, routing
+    /// through `/usr/bin/arch -arm64` when this process runs under Rosetta 2
+    /// against an arm-native Homebrew (`/opt/homebrew`). Without this, a
+    /// translated (x86_64) process spawning arm `brew` fails with "Cannot
+    /// install under Rosetta 2 in ARM default prefix" (issue #158). An Intel
+    /// brew at `/usr/local` already matches the translated process, so it's
+    /// left alone. Every brew spawn site goes through this.
+    static func brewInvocation(brew: String, args: [String])
+        -> (executable: URL, arguments: [String])
+    {
+        if SystemProfile.isTranslated() && brew.hasPrefix("/opt/homebrew") {
+            return (URL(fileURLWithPath: "/usr/bin/arch"), ["-arm64", brew] + args)
+        }
+        return (URL(fileURLWithPath: brew), args)
+    }
+
     private func runCapture(_ args: [String]) async throws -> String {
         guard let brew = Self.resolveBrewPath() else { throw BrewError.brewNotFound }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: brew)
-        process.arguments = args
+        let invocation = Self.brewInvocation(brew: brew, args: args)
+        process.executableURL = invocation.executable
+        process.arguments = invocation.arguments
         process.currentDirectoryURL = URL(fileURLWithPath: "/")
         process.environment = Self.brewEnvironment()
 
@@ -314,8 +331,9 @@ struct BrewService: Sendable {
                 return
             }
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: brew)
-            process.arguments = args
+            let invocation = Self.brewInvocation(brew: brew, args: args)
+            process.executableURL = invocation.executable
+            process.arguments = invocation.arguments
             process.currentDirectoryURL = URL(fileURLWithPath: "/")
             // No TTY/stdin: a sudo/interactive prompt gets EOF → brew errors out
             // visibly instead of blocking on a read that never returns.

--- a/native/Sources/BrewBrowserKit/DashboardView.swift
+++ b/native/Sources/BrewBrowserKit/DashboardView.swift
@@ -14,6 +14,9 @@ struct DashboardView: View {
     /// True when the content pane is wide enough to pair cards two-across.
     @State private var wide = false
 
+    /// Issue #158 — session-only dismissal of the Rosetta 2 notice card.
+    @State private var rosettaDismissed = false
+
     var body: some View {
         ScrollView {
             if !model.dashboardLoaded {
@@ -21,6 +24,12 @@ struct DashboardView: View {
                     .frame(maxWidth: .infinity, minHeight: 300)
             } else {
                 VStack(alignment: .leading, spacing: 16) {
+                    // Issue #158 — Rosetta 2 notice, at the top of the stack when
+                    // the app is running under Rosetta 2 (Intel build on Apple
+                    // Silicon). Same card language as the other dashboard cards.
+                    if model.rosettaTranslated && !rosettaDismissed {
+                        RosettaCard { rosettaDismissed = true }
+                    }
                     HeroStrip(model: model)
                     CatalogFreshnessStrip(model: model)
                     if model.outdatedCount > 0 { UpdatesCard(model: model) }
@@ -805,6 +814,55 @@ struct GitHubCard: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 2)
+        }
+    }
+}
+
+/// Issue #158 — Rosetta 2 notice card. Shown at the top of the Dashboard when
+/// the app is running under Rosetta 2 (an Intel build on an Apple Silicon Mac).
+/// `BrewService.brewInvocation` routes `brew` through `arch -arm64` so it keeps
+/// working, but Apple is retiring Rosetta 2, so the durable fix is the native
+/// Apple Silicon build. Same `GroupBox` + warning-`Label` language as
+/// `ExposureCard`. Visibility + session dismissal are owned by `DashboardView`.
+struct RosettaCard: View {
+    /// Called when the user dismisses the notice for this session.
+    let onDismiss: () -> Void
+
+    private let releasesURL = URL(string: "https://github.com/msitarzewski/brew-browser/releases/latest")!
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Image(systemName: "cpu").foregroundStyle(.orange)
+                    Text("Rosetta 2").font(.headline)
+                    Spacer()
+                    Link(destination: releasesURL) {
+                        Label("Apple Silicon Build", systemImage: "arrow.down.circle")
+                    }
+                    .controlSize(.small)
+                    Button {
+                        onDismiss()
+                    } label: {
+                        Image(systemName: "xmark").imageScale(.small)
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .help("Dismiss for this session")
+                    .accessibilityLabel("Dismiss Rosetta 2 notice")
+                }
+
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Running under Rosetta 2").fontWeight(.semibold)
+                        Text("You installed the Intel build on an Apple Silicon Mac. It keeps working — Homebrew runs through arch -arm64 — but Apple is retiring Rosetta 2. Switch to the Apple Silicon build for full, future-proof support.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
     }
 }

--- a/native/Sources/BrewBrowserKit/SystemProfile.swift
+++ b/native/Sources/BrewBrowserKit/SystemProfile.swift
@@ -69,6 +69,39 @@ public struct SystemProfile: Sendable, Codable, Equatable {
     }
 }
 
+// MARK: - Rosetta 2 detection (issue #158)
+
+extension SystemProfile {
+    /// True when this process is running under Rosetta 2 — an x86_64 build
+    /// translated on Apple Silicon. A translated process shelling out to
+    /// arm-native `brew` (`/opt/homebrew`) fails with "Cannot install under
+    /// Rosetta 2 in ARM default prefix", so we detect this both to warn the
+    /// user (install the Apple Silicon build) and to re-exec `brew` through
+    /// `arch -arm64`. Reads the per-process `sysctl.proc_translated` flag:
+    /// `1` translated, `0`/absent (Macs without Rosetta) native.
+    ///
+    /// Note: this is a *runtime* check — the compile-time `#if arch(arm64)`
+    /// in `detect()` can't see translation, since an x86_64 build reports
+    /// itself as Intel even on Apple Silicon hardware.
+    public static func isTranslated() -> Bool {
+        // Debug/QA override — mirrors `BREWBROWSER_FAKE_RAM_GB` in `detect()`.
+        // Lets the Rosetta banner + `arch -arm64` bridge be exercised on a
+        // native Apple Silicon Mac (where `proc_translated` is always 0). Safe:
+        // `arch -arm64` on an already-arm `brew` is a no-op wrapper.
+        if let fake = ProcessInfo.processInfo.environment["BREWBROWSER_FAKE_ROSETTA"] {
+            return fake == "1"
+        }
+        return translatedFromSysctl(sysctlInt("sysctl.proc_translated"))
+    }
+}
+
+/// Pure mapping behind `isTranslated()`, split out so the flag semantics are
+/// unit-testable without a real Rosetta process. `1` → translated; `0`, `nil`
+/// (key absent), and anything else → native.
+func translatedFromSysctl(_ value: Int?) -> Bool {
+    value == 1
+}
+
 // MARK: - sysctl helpers
 
 /// Read a string-valued `sysctl` (e.g. `machdep.cpu.brand_string`).

--- a/native/Tests/BrewBrowserKitTests/RosettaDetectionTests.swift
+++ b/native/Tests/BrewBrowserKitTests/RosettaDetectionTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import BrewBrowserKit
+
+/// Rosetta 2 detection + `arch -arm64` re-exec gating (issue #158). Parity with
+/// the Tauri suite (`profile.rs::translated_only_when_sysctl_reads_one` and
+/// `exec.rs::arm64_reexec_only_for_translated_arm_prefix`).
+@Suite("RosettaDetection")
+struct RosettaDetectionTests {
+
+    @Test("sysctl.proc_translated maps to translated only when it reads 1")
+    func translatedFlagMapping() {
+        // 1 = Rosetta 2, 0 = native, nil = key absent (Macs without Rosetta).
+        #expect(translatedFromSysctl(1) == true)
+        #expect(translatedFromSysctl(0) == false)
+        #expect(translatedFromSysctl(nil) == false)
+        // Defensive: any other value is treated as native, never "translated".
+        #expect(translatedFromSysctl(2) == false)
+        #expect(translatedFromSysctl(-1) == false)
+    }
+
+    @Test("brewInvocation re-execs via arch -arm64 only for translated + /opt/homebrew")
+    func brewInvocationGating() {
+        // The gating logic mirrors the Rust `should_reexec_arm64`. We can't
+        // fake Rosetta at runtime, but we can pin the wrapping shape: an
+        // arm-prefix brew under `arch -arm64` must run `arch -arm64 <brew> …`,
+        // and a direct invocation must run `<brew> …` verbatim.
+        let args = ["upgrade", "wget"]
+
+        let direct = BrewService.brewInvocation(brew: "/opt/homebrew/bin/brew", args: args)
+        let wrapped = (URL(fileURLWithPath: "/usr/bin/arch"), ["-arm64", "/opt/homebrew/bin/brew"] + args)
+
+        // On a native (non-translated) machine — which the CI/dev host is —
+        // brewInvocation must NOT wrap, regardless of prefix.
+        if SystemProfile.isTranslated() {
+            #expect(direct.executable == wrapped.0)
+            #expect(direct.arguments == wrapped.1)
+        } else {
+            #expect(direct.executable == URL(fileURLWithPath: "/opt/homebrew/bin/brew"))
+            #expect(direct.arguments == args)
+        }
+
+        // An Intel brew (/usr/local) already matches a translated process, so it
+        // is never wrapped — direct invocation on every host.
+        let intel = BrewService.brewInvocation(brew: "/usr/local/bin/brew", args: args)
+        #expect(intel.executable == URL(fileURLWithPath: "/usr/local/bin/brew"))
+        #expect(intel.arguments == args)
+    }
+}

--- a/src-tauri/src/brew/exec.rs
+++ b/src-tauri/src/brew/exec.rs
@@ -87,19 +87,55 @@ pub(crate) fn apply_brew_env(cmd: &mut Command) {
     cmd.env("PATH", new_path);
 }
 
+/// True when brew must be launched through `arch -arm64`: this process is
+/// running under Rosetta 2 (an Intel build on Apple Silicon) *and* the resolved
+/// `brew` lives in the arm-native prefix (`/opt/homebrew`). In that state a
+/// translated (x86_64) process spawning arm `brew` fails with
+/// "Cannot install under Rosetta 2 in ARM default prefix" (issue #158), so we
+/// re-exec it natively. An Intel Homebrew at `/usr/local` already matches the
+/// translated process, so we leave those untouched.
+fn needs_arm64_reexec(brew_path: &Path) -> bool {
+    should_reexec_arm64(crate::system::profile::is_translated(), brew_path)
+}
+
+/// Pure gating logic behind [`needs_arm64_reexec`], split out so the
+/// `translated` + arm-prefix combination is unit-testable without a real
+/// Rosetta process.
+fn should_reexec_arm64(translated: bool, brew_path: &Path) -> bool {
+    translated && brew_path.starts_with("/opt/homebrew")
+}
+
+/// Construct the `brew` command with the analytics-off env + Homebrew PATH
+/// prepend applied ([`apply_brew_env`]), transparently routing through
+/// `/usr/bin/arch -arm64` when [`needs_arm64_reexec`] is true. Every brew spawn
+/// site goes through this so the Rosetta 2 stopgap and the env policy stay in
+/// one place. Subsequent `.args(..)` on the returned command append the brew
+/// arguments as normal (after the `brew` path when re-execing via `arch`).
+pub(crate) fn brew_command(brew_path: &Path) -> Command {
+    if needs_arm64_reexec(brew_path) {
+        let mut cmd = Command::new("/usr/bin/arch");
+        cmd.arg("-arm64").arg(brew_path);
+        apply_brew_env(&mut cmd);
+        cmd
+    } else {
+        let mut cmd = Command::new(brew_path);
+        apply_brew_env(&mut cmd);
+        cmd
+    }
+}
+
 pub async fn run_brew_capture(
     brew_path: &Path,
     args: &[&str],
     display_command: &str,
 ) -> Result<String, BrewError> {
-    let mut cmd = Command::new(brew_path);
+    let mut cmd = brew_command(brew_path);
     cmd.args(args)
         .current_dir(BREW_SPAWN_CWD)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    apply_brew_env(&mut cmd);
 
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
@@ -151,14 +187,13 @@ pub async fn run_brew_streaming(
 
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-    let mut cmd = Command::new(brew_path);
+    let mut cmd = brew_command(brew_path);
     cmd.args(&str_args)
         .current_dir(BREW_SPAWN_CWD)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    apply_brew_env(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -546,6 +581,32 @@ mod tests {
             BREW_ENV.contains(&("HOMEBREW_NO_ANALYTICS", "1")),
             "brew spawn env must disable Homebrew analytics"
         );
+    }
+
+    #[test]
+    fn arm64_reexec_only_for_translated_arm_prefix() {
+        use std::path::Path;
+        // Under Rosetta 2, an arm-native brew (/opt/homebrew) must be re-execed
+        // via `arch -arm64` (issue #158)...
+        assert!(should_reexec_arm64(
+            true,
+            Path::new("/opt/homebrew/bin/brew")
+        ));
+        // ...but an Intel brew (/usr/local) already matches the translated
+        // process — leave it alone.
+        assert!(!should_reexec_arm64(
+            true,
+            Path::new("/usr/local/bin/brew")
+        ));
+        // Native (non-translated) process: never re-exec, regardless of prefix.
+        assert!(!should_reexec_arm64(
+            false,
+            Path::new("/opt/homebrew/bin/brew")
+        ));
+        assert!(!should_reexec_arm64(
+            false,
+            Path::new("/usr/local/bin/brew")
+        ));
     }
 
     #[test]

--- a/src-tauri/src/commands/brewfile.rs
+++ b/src-tauri/src/commands/brewfile.rs
@@ -95,7 +95,9 @@ pub async fn brewfile_check(
     let display = format!("brew bundle check --file={} --verbose", target_str);
     // `brew bundle check` exits non-zero when packages are missing —
     // we want to read the output even then, so capture via plain output.
-    let mut cmd = tokio::process::Command::new(&path);
+    // `brew_command` applies the analytics-off env + PATH prepend and routes
+    // through `arch -arm64` under Rosetta 2 (issue #158).
+    let mut cmd = crate::brew::exec::brew_command(&path);
     cmd.args([
         "bundle",
         "check",

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -74,6 +74,11 @@ pub struct SystemStatus {
     pub brew_found: bool,
     pub brew_path: Option<String>,
     pub clt_found: bool,
+    /// True when the app itself is running under Rosetta 2 (an Intel build on
+    /// an Apple Silicon Mac). Drives the "install the Apple Silicon build"
+    /// banner — brew can't install into the arm `/opt/homebrew` prefix from a
+    /// translated process without the `arch -arm64` stopgap. See issue #158.
+    pub rosetta_translated: bool,
 }
 
 impl SystemStatus {
@@ -82,6 +87,7 @@ impl SystemStatus {
             brew_found: path.is_some(),
             brew_path: path.map(|p| p.to_string_lossy().into_owned()),
             clt_found,
+            rosetta_translated: crate::system::profile::is_translated(),
         }
     }
 }
@@ -183,12 +189,18 @@ mod tests {
             brew_found: true,
             brew_path: Some("/opt/homebrew/bin/brew".into()),
             clt_found: false,
+            rosetta_translated: true,
         };
         let v: Value = serde_json::to_value(&s).unwrap();
         // Critical: must be camelCase for the frontend's SystemStatus type.
         assert_eq!(v["brewFound"], true);
         assert_eq!(v["brewPath"], "/opt/homebrew/bin/brew");
         assert_eq!(v["cltFound"], false);
+        assert_eq!(v["rosettaTranslated"], true);
+        assert!(
+            v.get("rosetta_translated").is_none(),
+            "must not emit snake_case `rosetta_translated`"
+        );
         assert!(
             v.get("brew_found").is_none(),
             "must not emit snake_case `brew_found`"
@@ -209,6 +221,7 @@ mod tests {
             brew_found: false,
             brew_path: None,
             clt_found: true,
+            rosetta_translated: false,
         };
         let v: Value = serde_json::to_value(&s).unwrap();
         assert_eq!(v["brewFound"], false);

--- a/src-tauri/src/system/profile.rs
+++ b/src-tauri/src/system/profile.rs
@@ -10,6 +10,7 @@
 //! `AppState` cache — the readiness math that consumes it lives client-side.
 
 use std::process::Command;
+use std::sync::OnceLock;
 
 use serde::Serialize;
 
@@ -56,6 +57,39 @@ fn capture(cmd: &str, args: &[&str]) -> Option<String> {
 /// Bytes → GiB, rounded to the nearest whole GB.
 fn bytes_to_gb(bytes: u64) -> u64 {
     (bytes as f64 / GIB).round() as u64
+}
+
+/// Parse the `sysctl.proc_translated` value: `"1"` means this process is being
+/// translated by Rosetta 2, anything else (including a missing key on Macs
+/// without Rosetta, which reads back as `None`) means native. Split out from
+/// [`is_translated`] so the mapping is unit-testable without a real `sysctl`.
+fn translated_from_sysctl(value: Option<&str>) -> bool {
+    value == Some("1")
+}
+
+/// True when this process is an x86_64 binary translated by Rosetta 2 on an
+/// Apple Silicon Mac. Reads the per-process `sysctl.proc_translated` flag
+/// (`0` native, `1` translated; absent → native). Cached for the process
+/// lifetime — translation state is fixed at launch and never changes.
+/// macOS-only; always `false` elsewhere.
+///
+/// A translated (Intel) build spawning arm-native `brew` fails with
+/// "Cannot install under Rosetta 2 in ARM default prefix" (issue #158), so we
+/// detect this both to warn the user to install the Apple Silicon build and to
+/// route `brew` through `arch -arm64` as a stopgap. Apple retires Rosetta 2 in
+/// a future macOS release, so the native build is the durable fix.
+pub fn is_translated() -> bool {
+    static TRANSLATED: OnceLock<bool> = OnceLock::new();
+    *TRANSLATED.get_or_init(|| {
+        // Debug/QA override — mirrors `BREWBROWSER_FAKE_RAM_GB` in `detect()`.
+        // Lets the Rosetta banner + `arch -arm64` bridge be exercised on a
+        // native Apple Silicon Mac (where `proc_translated` is always 0). Safe:
+        // `arch -arm64` on an already-arm `brew` is a no-op wrapper.
+        if let Ok(v) = std::env::var("BREWBROWSER_FAKE_ROSETTA") {
+            return v == "1";
+        }
+        translated_from_sysctl(capture("sysctl", &["-n", "sysctl.proc_translated"]).as_deref())
+    })
 }
 
 /// Free bytes on `/` via `df -Pk /`. The POSIX (`-P`) format guarantees a
@@ -261,5 +295,17 @@ mod tests {
         assert_eq!(bytes_to_gb(128 * 1024 * 1024 * 1024), 128);
         assert_eq!(bytes_to_gb(8 * 1024 * 1024 * 1024), 8);
         assert_eq!(bytes_to_gb(0), 0);
+    }
+
+    #[test]
+    fn translated_only_when_sysctl_reads_one() {
+        // `sysctl.proc_translated`: 1 = Rosetta 2, 0 = native, absent = native.
+        assert!(translated_from_sysctl(Some("1")));
+        assert!(!translated_from_sysctl(Some("0")));
+        assert!(!translated_from_sysctl(None));
+        // Defensive: any unexpected payload is treated as native, never
+        // silently "translated".
+        assert!(!translated_from_sysctl(Some("")));
+        assert!(!translated_from_sysctl(Some("yes")));
     }
 }

--- a/src-tauri/src/vulns/client.rs
+++ b/src-tauri/src/vulns/client.rs
@@ -31,9 +31,8 @@ use std::path::Path;
 use std::process::Stdio;
 
 use serde::{Deserialize, Deserializer, Serialize};
-use tokio::process::Command;
 
-use crate::brew::exec::{apply_brew_env, run_brew_capture};
+use crate::brew::exec::{brew_command, run_brew_capture};
 use crate::error::{truncate_tail, BrewError};
 
 /// Tolerant subprocess wrapper for `brew vulns`. Differs from
@@ -51,13 +50,12 @@ async fn run_vulns_capture(
     args: &[&str],
     display_command: &str,
 ) -> Result<String, BrewError> {
-    let mut cmd = Command::new(brew);
+    let mut cmd = brew_command(brew);
     cmd.args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    apply_brew_env(&mut cmd);
 
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
@@ -272,13 +270,12 @@ pub async fn check_brew_vulns_installed(brew: &Path) -> Result<bool, BrewError> 
     // affordance regardless).
     //
     // First try the legacy check: `brew --prefix brew-vulns` (if installed via custom tap).
-    let mut cmd = Command::new(brew);
+    let mut cmd = brew_command(brew);
     cmd.args(["--prefix", "brew-vulns"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    apply_brew_env(&mut cmd);
 
     if let Ok(output) = cmd.output().await {
         if output.status.success() {
@@ -287,13 +284,12 @@ pub async fn check_brew_vulns_installed(brew: &Path) -> Result<bool, BrewError> 
     }
 
     // Fallback: check if `vulns` is a built-in subcommand in Homebrew 6.0+ via `brew help vulns`.
-    let mut cmd = Command::new(brew);
+    let mut cmd = brew_command(brew);
     cmd.args(["help", "vulns"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    apply_brew_env(&mut cmd);
 
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
@@ -500,13 +496,12 @@ pub fn looks_like_subcommand_missing(stderr_excerpt: &str) -> bool {
 /// diagnostics.
 #[allow(dead_code)]
 async fn brew_version(brew: &Path) -> Result<String, BrewError> {
-    let mut cmd = Command::new(brew);
+    let mut cmd = brew_command(brew);
     cmd.args(["--version"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    apply_brew_env(&mut cmd);
     let output = cmd.output().await.map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => BrewError::BrewNotFound,
         _ => BrewError::Io {

--- a/src/lib/components/Dashboard.svelte
+++ b/src/lib/components/Dashboard.svelte
@@ -18,6 +18,10 @@
   import Star from "@lucide/svelte/icons/star";
   import GitBranch from "@lucide/svelte/icons/git-branch";
   import Loader from "@lucide/svelte/icons/loader-2";
+  import Cpu from "@lucide/svelte/icons/cpu";
+  import Download from "@lucide/svelte/icons/download";
+  import X from "@lucide/svelte/icons/x";
+  import { safeOpenUrl } from "$lib/util/url";
   import { packages } from "$lib/stores/packages.svelte";
   import { env } from "$lib/stores/env.svelte";
   import { categories } from "$lib/stores/categories.svelte";
@@ -42,6 +46,11 @@
   let disk = $state<DiskUsageReport | null>(null);
   let diskLoading = $state(false);
   let diskError = $state<string | null>(null);
+
+  // Issue #158 — Rosetta 2 notice card. Shown when the app runs under Rosetta 2
+  // (Intel build on Apple Silicon); dismissible for the session only.
+  const ROSETTA_RELEASES_URL = "https://github.com/msitarzewski/brew-browser/releases/latest";
+  let rosettaDismissed = $state(false);
 
   // Issue #80 — cache maintenance (brew doctor / cleanup), surfaced on the
   // Storage card since that's the disk surface and already shows the cache size.
@@ -611,6 +620,51 @@
        is dropped entirely. -->
 
   <div class="body">
+    <!-- Issue #158 — Rosetta 2 notice. Independent of package load state, so it
+         sits above the loading/error gate. Same card + warning-row language as
+         the Exposure card. -->
+    {#if env.rosettaTranslated && !rosettaDismissed}
+      <section class="card rosetta-card">
+        <div class="card-head">
+          <h2><span class="rosetta-card-icon"><Cpu size={16} /></span> Rosetta 2</h2>
+          <div class="head-right">
+            <Button
+              size="sm"
+              variant="secondary"
+              onclick={() => safeOpenUrl(ROSETTA_RELEASES_URL)}
+              title="Open the latest release to download the Apple Silicon build"
+            >
+              {#snippet icon()}<Download size={14} />{/snippet}
+              Apple Silicon build
+            </Button>
+            <button
+              type="button"
+              class="rosetta-dismiss"
+              onclick={() => (rosettaDismissed = true)}
+              aria-label="Dismiss Rosetta 2 notice"
+              title="Dismiss for this session"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+        <div class="rosetta-body">
+          <div class="rosetta-warn">
+            <AlertCircle size={20} class="rosetta-warn-icon" />
+            <div>
+              <strong>Running under Rosetta 2</strong>
+              <p class="text-muted rosetta-sub">
+                You installed the Intel build on an Apple&nbsp;Silicon Mac. It
+                keeps working — Homebrew runs through <code>arch -arm64</code> —
+                but Apple is retiring Rosetta&nbsp;2. Switch to the
+                Apple&nbsp;Silicon build for full, future-proof support.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    {/if}
+
     {#if packages.loading && !packages.list}
       <LoadingState rows={6} label="Loading your packages…" />
     {:else if packages.error}
@@ -1679,6 +1733,66 @@
     vertical-align: middle;
     margin-right: 4px;
     color: var(--color-text-secondary);
+  }
+
+  /* Issue #158 — Rosetta 2 notice card. Mirrors the Exposure card's
+     warning-row treatment (icon + bold title + muted description). */
+  .rosetta-card-icon {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    margin-right: 4px;
+    color: var(--color-warning-strong);
+  }
+  .rosetta-body {
+    padding: var(--space-4);
+  }
+  .rosetta-warn {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-3);
+    align-items: start;
+    padding: var(--space-3);
+    background: var(--color-warning-subtle);
+    border-radius: var(--radius-md);
+    color: var(--color-warning-on-subtle);
+  }
+  .rosetta-warn :global(.rosetta-warn-icon) {
+    color: var(--color-warning-on-subtle);
+  }
+  .rosetta-warn strong {
+    display: block;
+    font-size: var(--text-body);
+    font-weight: var(--fw-semibold);
+    color: var(--color-warning-on-subtle);
+  }
+  .rosetta-sub {
+    margin-top: 2px;
+    font-size: var(--text-body-sm);
+    line-height: var(--lh-snug);
+  }
+  .rosetta-sub code {
+    font-family: var(--font-mono);
+    font-size: var(--text-mono);
+  }
+  .rosetta-dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition:
+      background var(--motion-duration-fast) var(--motion-ease-out),
+      color var(--motion-duration-fast) var(--motion-ease-out);
+  }
+  .rosetta-dismiss:hover {
+    background: var(--color-surface-sunken);
+    color: var(--color-text-primary);
   }
   .exp-body {
     padding: var(--space-4);

--- a/src/lib/stores/env.svelte.ts
+++ b/src/lib/stores/env.svelte.ts
@@ -42,6 +42,13 @@ class EnvStore {
    */
   brewMissing = $derived(this.statusChecked && this.status?.brewFound === false);
 
+  /**
+   * True when the app itself is running under Rosetta 2 (an Intel build on
+   * Apple Silicon). Drives the RosettaBanner, which steers the user to the
+   * native Apple Silicon build. See issue #158.
+   */
+  rosettaTranslated = $derived(this.status?.rosettaTranslated === true);
+
   /** Human-readable summary for a tooltip. */
   summary = $derived.by(() => {
     if (this.loading && !this.report) return "Checking Homebrew…";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,13 @@ export interface SystemStatus {
   brewFound: boolean;
   brewPath: string | null;
   cltFound: boolean;
+  /**
+   * True when the app is running under Rosetta 2 (an Intel build on an Apple
+   * Silicon Mac). Drives the "install the Apple Silicon build" banner — a
+   * translated process can't install into the arm `/opt/homebrew` prefix
+   * without the `arch -arm64` stopgap. See issue #158.
+   */
+  rosettaTranslated: boolean;
 }
 
 // =========================================================


### PR DESCRIPTION
## What & why

Fixes **#158** — `Error: Cannot install under Rosetta 2 in ARM default prefix` on Apple Silicon. A translated (x86_64) build of the app spawning arm-native `brew` at `/opt/homebrew` is rejected by Homebrew. Apple is winding Rosetta 2 down (largely ends macOS 28), so this hardens detection and keeps brew working when the app is running translated.

## Approach (both shells)

**Runtime detection, not compile-time.** Uses `sysctl.proc_translated` (`1` = translated), because an x86_64 build cannot see its own translation via `#if arch(...)` / `cfg!(target_arch)`.

1. **Detect** — `is_translated()` / `SystemProfile.isTranslated()`, cached; honors `BREWBROWSER_FAKE_ROSETTA=1` for QA.
2. **Bridge** — when translated **and** the brew prefix is `/opt/homebrew`, spawn brew via `/usr/bin/arch -arm64 <brew> <args>`. Intel brew at `/usr/local` is left untouched.
3. **Notice** — a dismissible Dashboard card (mirrors the existing Exposure card style in both shells) telling the user they're under Rosetta 2 and pointing at the Apple Silicon build.

## Files
- **Tauri/Rust:** `system/profile.rs` (detection), `brew/exec.rs` (`arch -arm64` bridge + `brew_command`), converted spawn sites in `vulns/client.rs`, `commands/brewfile.rs`; `commands/env.rs` exposes `rosettaTranslated`.
- **Web:** `types.ts`, `stores/env.svelte.ts`, `Dashboard.svelte` (notice card).
- **Native:** `SystemProfile.swift`, `BrewService.swift` (`brewInvocation`), `AppModel.swift`, `DashboardView.swift` (`RosettaCard`), `RosettaDetectionTests.swift`.

## Tests
- Rust: `translated_only_when_sysctl_reads_one`, `arm64_reexec_only_for_translated_arm_prefix` — full suite green.
- Native: `RosettaDetectionTests` (sysctl mapping + `brewInvocation` gating) — green.
- svelte-check clean, vitest green.
- Empirically verified `arch -arm64 /opt/homebrew/bin/brew --version` succeeds and the card renders under `BREWBROWSER_FAKE_ROSETTA=1`.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
